### PR TITLE
Fix exceptions while parsing query parameters

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/utils/RequestUtils.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/utils/RequestUtils.java
@@ -345,11 +345,27 @@ public final class RequestUtils
     String[] pairs = query.split("&");
     for ( String pair : pairs )
     {
+      if (StringUtils.isBlank(pair) || pair.charAt(0) == '=')
+      {
+        continue;
+      }
       int index = pair.indexOf("=");
+      String param;
+      String value;
+      if (index == -1)
+      {
+        param = pair;
+        value = "";
+      }
+      else
+      {
+        param = pair.substring(0, index);
+        value = pair.substring(index + 1);
+      }
       try
       {
-        queryParameter.put(URLDecoder.decode(pair.substring(0, index).toLowerCase(), StandardCharsets.UTF_8.name()),
-                           URLDecoder.decode(pair.substring(index + 1), StandardCharsets.UTF_8.name()));
+        queryParameter.put(URLDecoder.decode(param.toLowerCase(), StandardCharsets.UTF_8.name()),
+                           URLDecoder.decode(value, StandardCharsets.UTF_8.name()));
       }
       catch (UnsupportedEncodingException e)
       {

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/utils/RequestUtilsTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/utils/RequestUtilsTest.java
@@ -80,4 +80,12 @@ public class RequestUtilsTest
   {
     Assertions.assertThrows(BadRequestException.class, () -> RequestUtils.getAttributes(attributes));
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"p1=v1", "p1=v1&p2=v2", "&p1=v1&&p2=v2&", "p1=&p2=", "p1&p2", "=v1&=v2"})
+  public void testGetQueryParameters(String query)
+  {
+    Assertions.assertDoesNotThrow(() -> RequestUtils.getQueryParameters(query));
+  }
+
 }


### PR DESCRIPTION
Do not unexpectedly fail during query parameter parsing when query
parameter without an '=' is encountered. Assume that such parameter has
an empty value.

Also, ignore some other harmless errors in query parameters to make
parsing more robust.

fixes #125