### PR TITLE
Update Lombok to 1.18.20 to support Java 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <formatter-path>${project.parent.basedir}</formatter-path>
 
-        <version.lombok>1.18.18</version.lombok>
+        <version.lombok>1.18.20</version.lombok>
 
         <!-- application dependencies -->
         <version.apache.commons.lang3>3.12.0</version.apache.commons.lang3>

--- a/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/http/ScimHttpClientSpringBootTest.java
+++ b/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/http/ScimHttpClientSpringBootTest.java
@@ -202,7 +202,7 @@ public class ScimHttpClientSpringBootTest extends AbstractSpringBootWebTest
     {
       log.debug(ex.getMessage(), ex);
       Assertions.assertEquals("communication with server failed", ex.getMessage());
-      MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.containsString("(Connection refused)"));
+      MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.containsString("Connection refused"));
     }
   }
 


### PR DESCRIPTION
When running under Java 16 the following error is recieved:
> java: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x45155c3f) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x45155c3f

This PR updates Lombok to 1.18.20 which adds support for Java 16.

There is an additional change to `ScimHttpClientSpringBootTest` which fixes a string search for an error string which changed in Java 16.