### PR TITLE
Delombok the source jars so they match the running code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,11 @@
     </dependencies>
 
     <build>
+        <!-- This is used in conjunction with the lombok-maven-plugin to generate delomboked sources, -->
+        <!-- effectively this switches the default sourceDirectory with the delomboked version. -->
+        <sourceDirectory>target/generated-sources/delombok</sourceDirectory>
+        <testSourceDirectory>target/generated-test-sources/delombok</testSourceDirectory>
+
         <finalName>${project.artifactId}-${project.version}</finalName>
 
         <pluginManagement>
@@ -436,6 +441,36 @@
 
         <plugins>
             <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>${version.lombok}.0</version>
+                <executions>
+                    <execution>
+                        <id>delombok</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                        <configuration>
+                            <addOutputDirectory>false</addOutputDirectory>
+                            <sourceDirectory>src/main/java</sourceDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-delombok</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>testDelombok</goal>
+                        </goals>
+                        <configuration>
+                            <addOutputDirectory>false</addOutputDirectory>
+                            <sourceDirectory>src/test/java</sourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.maven.compiler.plugin}</version>
@@ -462,6 +497,10 @@
                 <configuration>
                     <configFile>${formatter-path}/formatter.xml</configFile>
                     <lineEnding>LF</lineEnding>
+                    <!-- delomboked sources do not conform to the formatter and use of the -->
+                    <!-- lombok plugin changes sourceDirectory and testSourceDirectory -->
+                    <sourceDirectory>src/main/java</sourceDirectory>
+                    <testSourceDirectory>src/test/java</testSourceDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
fixes #133

This is pretty hard to get right; there are a few methods for accomplishing this:
* http://anthonywhitford.com/lombok.maven/lombok-maven-plugin/faq.html#alt-src-setup
* https://stackoverflow.com/questions/52362413/create-and-install-de-lomboked-source-jar-in-maven
* https://sudonull.com/post/1197-Lombok-sourcesjar-and-convenient-debug
* https://stackoverflow.com/questions/11329965/how-to-ignore-the-java-source-directory-during-maven-compilation

The main integration problem I came across was with the formatting plugin as the generated lombok sources don't conform to the required style. I've added comments to help explain what is going on, but happy to explain further.

Also, sorry about the reduced coverage, there's just more code due to the delomboked sources being used.