### PR TITLE
Log warning when returning empty list

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointHandler.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointHandler.java
@@ -569,7 +569,8 @@ class ResourceEndpointHandler
         }
         else
         {
-          // startIndex is greater than the number of entries available so we will return an empty list
+          log.warn("startIndex {} > than number of entries available after autofiltering {}. Returning empty list", 
+                   effectiveStartIndex, filteredResources.size());
           filteredResources = Collections.emptyList();
         }
       }


### PR DESCRIPTION
This code took me a painful debugging session to find. Having a warning instead of a comment is simple and will help the next person. If I understand properly, this is indeed a warning scenario - either the client passed a bad start index or there was some issue with calculating the total size originally or the dataset changed. So a warning seems appropriate here. Or the user is like me, and didn't immediately realize that you cannot magically start doing offset/limit without first turning off autofiltering ;-) 