### PR TITLE
Fix NPE if filtering by meta attribute

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/filter/AttributeExpressionLeaf.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/filter/AttributeExpressionLeaf.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import de.captaingoldfish.scim.sdk.common.constants.SchemaUris;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -96,7 +97,10 @@ public final class AttributeExpressionLeaf extends FilterNode
     this.compareValue = context.compareValue() == null ? null
       : new CompareValue(context.compareValue(), schemaAttribute);
     validateFilterComparator();
-    this.mainSchemaNode = resourceType.getMainSchema().getId().equals(schemaAttribute.getSchema().getId());
+    final Optional<String> attrSchemaId = schemaAttribute.getSchema().getId();
+    // meta attribute has no schema ID per RFC 7643 (3.1 Common Attributes)
+    this.mainSchemaNode = resourceType.getMainSchema().getId().equals(attrSchemaId)
+                          || SchemaUris.META.equals(attrSchemaId.orElse(null));
   }
 
   public String getParentAttributeName()


### PR DESCRIPTION
SCIM-SDK declares a schema for meta attribute, but it should be
evaluated as part of the main schema according to specification.

Meta attribute was evaluted as extension schema attribute causing NPE in
FilterResourceResolver.retrieveComplexAttributeNode() while filtering
resources.

Mark leaf filter node as main schama node to treat it correctly during
filtering. The mainSchemaNode flag is only used during filtering, so the
change should not break anything.

Fixes issue #168.