### PR TITLE
PatchHandler.isChangedResource should return true if any attribute ch…

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/PatchResourceHandler.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/PatchResourceHandler.java
@@ -101,7 +101,10 @@ public class PatchResourceHandler extends AbstractPatch
           MsAzurePatchResourceWorkaroundHandler workaroundHandler = new MsAzurePatchResourceWorkaroundHandler(resourceType);
           effectiveValue = workaroundHandler.rebuildResource(extensionRef, key, value);
         }
-        changeWasMade.set(addResourceValues((ObjectNode)complex, effectiveValue, extensionRef.getSchema()));
+        changeWasMade.weakCompareAndSet(false,
+                                        addResourceValues((ObjectNode)complex,
+                                                          effectiveValue,
+                                                          extensionRef.getSchema()));
       }
       else
       {

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchResourceWorkaroundHandlerTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchResourceWorkaroundHandlerTest.java
@@ -17,6 +17,7 @@ import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
 import de.captaingoldfish.scim.sdk.common.exceptions.BadRequestException;
 import de.captaingoldfish.scim.sdk.common.request.PatchOpRequest;
 import de.captaingoldfish.scim.sdk.common.request.PatchRequestOperation;
+import de.captaingoldfish.scim.sdk.common.resources.EnterpriseUser;
 import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
 import de.captaingoldfish.scim.sdk.server.resources.AllTypes;
 import de.captaingoldfish.scim.sdk.server.schemas.ResourceType;
@@ -114,6 +115,45 @@ public class MsAzurePatchResourceWorkaroundHandlerTest implements FileReferences
     Assertions.assertEquals(employeeNumber, patchedResource.getEnterpriseUser().get().getEmployeeNumber().get());
     Assertions.assertEquals(costCenter, patchedResource.getEnterpriseUser().get().getCostCenter().get());
   }
+
+
+  /**
+   * this will test that PatchHandler.isChangedResource is true if any attribute is changed, and not just if the
+   * last attributes is changed.
+   */
+  @Test
+  public void testIsChangedResourceForExtensionValueInMsAzureAdStyle()
+  {
+    String employeeNumber = "1111";
+    String employeeNumberChanged = "2222";
+    String costCenter = "2222";
+
+    AllTypes allTypeChanges = new AllTypes(true);
+    allTypeChanges.setEnterpriseUser(EnterpriseUser.builder()
+                                                   .employeeNumber(employeeNumber)
+                                                   .costCenter(costCenter)
+                                                   .build());
+
+    // @formatter:off
+    String valueNode = "{" +
+      "  \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber\": \"" +
+      employeeNumberChanged+ "\"," +
+      "  \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:costCenter\": \"" +
+      costCenter+ "\"" +
+      "}";
+    // @formatter:on
+
+    List<PatchRequestOperation> operations = Arrays.asList(PatchRequestOperation.builder()
+                                                                                .op(PatchOp.REPLACE)
+                                                                                .value(valueNode)
+                                                                                .build());
+    PatchOpRequest patchOpRequest = PatchOpRequest.builder().operations(operations).build();
+    PatchHandler patchHandler = new PatchHandler(allTypesResourceType);
+    patchHandler.patchResource(allTypeChanges, patchOpRequest);
+    Assertions.assertTrue(patchHandler.isChangedResource());
+  }
+
+
 
   /**
    * verifies that a complete complex type can be replaced if the value is set as object


### PR DESCRIPTION
…anges

In the below PATCH, if employeeNumber changes but costCenter does not, then isChangedResource should return true.

      {
        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
        "Operations": [
          {
            "op": "replace",
            "value": {
              "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber": "1111",
              "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:costCenter": "2222"
            }
          }
        ]
      }

Previsously changeWasMade would only reflect if the last attribute in the value list changed. Ff it had not,
then other changes would be lost (but the reponse would still look like all changes were successful).