### PR TITLE
Recognize attributes with value set to JSON null

### DIFF
--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/base/ScimObjectNode.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/base/ScimObjectNode.java
@@ -112,7 +112,7 @@ public class ScimObjectNode extends ObjectNode implements ScimNode
   protected <T extends TextNode> Optional<T> getStringAttribute(String attributeName, Class<T> type)
   {
     JsonNode jsonNode = this.get(attributeName);
-    if (jsonNode == null)
+    if (jsonNode == null || jsonNode.isNull())
     {
       return Optional.empty();
     }
@@ -143,7 +143,7 @@ public class ScimObjectNode extends ObjectNode implements ScimNode
   protected <T extends ObjectNode> Optional<T> getObjectAttribute(String attributeName, Class<T> type)
   {
     JsonNode jsonNode = this.get(attributeName);
-    if (jsonNode == null)
+    if (jsonNode == null || jsonNode.isNull())
     {
       return Optional.empty();
     }
@@ -167,7 +167,7 @@ public class ScimObjectNode extends ObjectNode implements ScimNode
   protected <T extends ObjectNode> List<T> getArrayAttribute(String attributeName, Class<T> type)
   {
     JsonNode jsonNode = this.get(attributeName);
-    if (jsonNode == null)
+    if (jsonNode == null || jsonNode.isNull())
     {
       return new ArrayList<>();
     }
@@ -229,7 +229,7 @@ public class ScimObjectNode extends ObjectNode implements ScimNode
                                         null);
     }
     JsonNode jsonNode = this.get(attributeName);
-    if (jsonNode == null)
+    if (jsonNode == null || jsonNode.isNull())
     {
       return new ArrayList<>();
     }
@@ -300,7 +300,7 @@ public class ScimObjectNode extends ObjectNode implements ScimNode
                                         null);
     }
     JsonNode jsonNode = this.get(attributeName);
-    if (jsonNode == null)
+    if (jsonNode == null || jsonNode.isNull())
     {
       return new HashSet<>();
     }

--- a/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/resources/base/ScimObjectNodeTest.java
+++ b/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/resources/base/ScimObjectNodeTest.java
@@ -10,6 +10,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -302,6 +305,29 @@ public class ScimObjectNodeTest implements FileReferences
                               .orElseThrow(() -> new IllegalStateException("fail"));
     Assertions.assertEquals(tag, eTag.getTag());
     Assertions.assertTrue(eTag.isWeak());
+  }
+
+  /**
+   * verifies that attributes set to JSON null are recognized
+   */
+  @Test
+  public void testRecognizeNullValue() throws JsonProcessingException
+  {
+    JsonNode jsonNode = new ObjectMapper().readTree("{\"attr\": null}");
+    ScimObjectNode scimObjectNode = new ScimObjectNode(null);
+    scimObjectNode.setAll((ObjectNode)jsonNode);
+    final String attributeName = "attr";
+
+    Assertions.assertFalse(scimObjectNode.getObjectAttribute(attributeName, AllTypes.class).isPresent());
+
+    Assertions.assertFalse(scimObjectNode.getStringAttribute(attributeName).isPresent());
+
+    Assertions.assertTrue(scimObjectNode.getArrayAttribute(attributeName, AllTypes.class).isEmpty());
+
+    Assertions.assertTrue(scimObjectNode.getSimpleArrayAttribute(attributeName, String.class).isEmpty());
+
+    Assertions.assertTrue(scimObjectNode.getSimpleArrayAttributeSet(attributeName, String.class).isEmpty());
+
   }
 
 }


### PR DESCRIPTION
Attributes set to JSON null are not interpreted as null and result in type mismatch. For example a User who has the following attribute `"name": null` will fail with: 
```
de.captaingoldfish.scim.sdk.common.exceptions.InternalServerException: \ 
tried to extract a multi valued complex node from document with \
attribute name 'name' but type is of: NULL
```
The reason for not catching it is that `this.get(attributeName)` will return a `NullNode` rather than `null`. Checking for the if the JsonNode is of `JsonNodeType.NULL` mitigates the issue.