### PR TITLE
MsAzure workaround: Patching User:name sub-attributes with nested dot…

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchReplaceWorkaroundHandler.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchReplaceWorkaroundHandler.java
@@ -1,0 +1,217 @@
+package de.captaingoldfish.scim.sdk.server.patch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
+import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
+import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * This class is a workaround handler in order to handle the broken patch requests of Microsoft Azure. Azure
+ * sends illegal patch-remove requests that looks as follows:
+ *
+ * <pre>
+ * PATCH /scim/Users/2752513
+ * {
+ *     "schemas": [
+ *         "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+ *     ],
+ *     "Operations": [
+ *         {
+ *             "op": "replace",
+ *             "value": {
+ *                 "name.givenName": "captain",
+ *                 "name.familyName": "goldfish"
+ *             }
+ *         }
+ *     ]
+ * }
+ * </pre>
+ *
+ * the value in the request must not be present. Instead the request should look like this:
+ *
+ * <pre>
+ * PATCH /scim/Users/2752513
+ * {
+ *     "schemas": [
+ *         "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+ *     ],
+ *     "Operations": [
+ *         {
+ *             "op": "replace",
+ *             "value": {
+ *                 "name": {
+ *                     "givenName": "captain",
+ *                     "familyName": "goldfish"
+ *                 }
+ *             }
+ *         }
+ *     ]
+ * }
+ * </pre>
+ */
+
+
+@Slf4j
+@RequiredArgsConstructor
+public final class MsAzurePatchReplaceWorkaroundHandler
+{
+
+  /**
+   * the patch operation that is currently executed
+   */
+  private final PatchOp patchOp;
+
+  /**
+   * the values of the patch operation. This attribute should actually be empty
+   */
+  private final List<String> values;
+
+
+  public List<String> fixValues()
+  {
+    // just a security check to make sure that the if-block that prevents this class to be executed in case of ADD
+    // and REMOVE should disappear
+    if (!PatchOp.REPLACE.equals(patchOp))
+    {
+      log.trace("[MS Azure REPLACE workaround] only handling 'REPLACE' requests");
+      return values;
+    }
+
+    // nothing must be done patch request can be handled normally since no illegal value operand is present
+    if (values.isEmpty())
+    {
+      log.trace("[MS Azure REPLACE workaround] workaround not executed for values-list is empty");
+      return values;
+    }
+
+    if (values.size() > 1)
+    {
+      log.trace("[MS Azure REPLACE workaround] workaround not executed for values-list with more than one value");
+      return values;
+    }
+
+    String value = values.get(0);
+
+    if (!JsonHelper.isValidJson(value))
+    {
+      // do nothing anymore this will cause the request to normally abort at the specific validation point
+      log.trace("[MS Azure REPLACE workaround] attribute in 'value' operand is not valid json: {}", value);
+      return values;
+    }
+
+    JsonNode jsonNode = JsonHelper.readJsonDocument(value);
+    final boolean isNodeAnObject = Optional.ofNullable(jsonNode).map(JsonNode::isObject).orElse(false);
+    if (!isNodeAnObject)
+    {
+      // do nothing anymore this will cause the request to normally abort at the specific validation point
+      log.trace("[MS Azure REPLACE workaround] attribute in 'value' operand is not an object: {}", value);
+      return values;
+    }
+    ObjectNode rootObjectNode = (ObjectNode)jsonNode;
+    List<ObjectNode> resourceObjectNodes = new ArrayList<ObjectNode>();
+    resourceObjectNodes.add(rootObjectNode);
+
+    Optional<List<String>> schemas = JsonHelper.getSimpleAttributeArray(rootObjectNode, AttributeNames.RFC7643.SCHEMAS);
+    if (schemas.isPresent())
+    {
+      // set extension resource object as resourceObjectNode if found
+      for ( Iterator<String> it = rootObjectNode.fieldNames() ; it.hasNext() ; )
+      {
+        String fieldName = it.next();
+
+        if (schemas.get().contains(fieldName))
+        {
+          JsonNode childNode = rootObjectNode.get(fieldName);
+
+          final boolean isChildNodeAnObject = Optional.ofNullable(childNode).map(JsonNode::isObject).orElse(false);
+          if (!isChildNodeAnObject)
+          {
+            // do nothing anymore this will cause the request to normally abort at the specific validation point
+            log.trace("[MS Azure REPLACE workaround] extension attribute in 'value' operand is not an object: {}",
+                      value);
+            return values;
+          }
+
+          resourceObjectNodes.add((ObjectNode)childNode);
+        }
+      }
+    }
+
+    boolean workaroundApplied = false;
+
+    for ( ObjectNode resourceObjectNode : resourceObjectNodes )
+    {
+      if (fixValuesForResourceObjectNode(resourceObjectNode))
+      {
+        workaroundApplied = true;
+      }
+    }
+
+    if (workaroundApplied)
+    {
+      List<String> newValues = Arrays.asList(JsonHelper.toJsonString(rootObjectNode));
+      return newValues;
+    }
+    else
+    {
+      return values;
+    }
+  }
+
+  private boolean fixValuesForResourceObjectNode(ObjectNode resourceObjectNode)
+  {
+    boolean workaroundApplied = false;
+
+    List<String> fieldNames = new ArrayList<>();
+    resourceObjectNode.fieldNames().forEachRemaining(fieldNames::add);
+
+    // apply workaround if necessary
+    for ( String originalFieldName : fieldNames )
+    {
+      if (originalFieldName.lastIndexOf(":") > -1)
+      {
+        // another resourceObjectNode, it is handled in the outer loop
+        continue;
+      }
+
+      String[] split = originalFieldName.split("\\.");
+
+      // only one level of nested dot notation supported
+      if (split.length == 2)
+      {
+        JsonNode originalFieldValue = resourceObjectNode.get(originalFieldName);
+
+        String fieldName = split[0];
+        String childFieldName = split[1];
+
+        JsonNode node = resourceObjectNode.get(fieldName);
+        if (node != null && node.isObject())
+        {
+          ((ObjectNode)node).set(childFieldName, originalFieldValue);
+        }
+        else
+        {
+          resourceObjectNode.putObject(fieldName).set(childFieldName, originalFieldValue);
+        }
+
+        resourceObjectNode.remove(originalFieldName);
+        workaroundApplied = true;
+      }
+    }
+
+    return workaroundApplied;
+  }
+}
+
+

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/PatchHandler.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/PatchHandler.java
@@ -172,6 +172,14 @@ public class PatchHandler
                                       + " a single value must be present in the values list which represents the "
                                       + "resource itself", null, ScimType.RFC7644.INVALID_VALUE);
       }
+
+      if (PatchOp.REPLACE.equals(operation.getOp()))
+      {
+        MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(operation.getOp(),
+                                                                                                                             values);
+        values = msAzurePatchReplaceWorkaroundHandler.fixValues();
+      }
+
       PatchResourceHandler patchResourceHandler = new PatchResourceHandler(resourceType, operation.getOp());
       boolean changeWasMade = patchResourceHandler.addResourceValues(resource,
                                                                      JsonHelper.readJsonDocument(values.get(0)),

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchReplaceWorkaroundHandlerTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/MsAzurePatchReplaceWorkaroundHandlerTest.java
@@ -1,0 +1,188 @@
+package de.captaingoldfish.scim.sdk.server.patch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
+
+
+public class MsAzurePatchReplaceWorkaroundHandlerTest
+{
+
+  /**
+   * verifies that the values is correctly handled in simple cases
+   */
+  @Test
+  public void testFixValues()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("{ \"name.givenName\": \"captain\", \"name.familyName\": \"goldfish\" }"));
+    final List<String> expectedValues = new ArrayList<>(Arrays.asList("{\"name\":{\"givenName\":\"captain\",\"familyName\":\"goldfish\"}}"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertIterableEquals(expectedValues, valuesResult);
+  }
+
+
+  /**
+   * verifies that the original values is returned on REMOVE and ADD operations
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"ADD", "REMOVE"})
+  public void testFixValuesWithIllegalPatchOp(PatchOp patchOp)
+  {
+    final List<String> values = new ArrayList<>(Arrays.asList("{ \"name.givenName\": \"captain\", \"name.familyName\": \"goldfish\" }"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned if the values operand is empty
+   */
+  @Test
+  public void testFixValuesWithValuesListEmpty()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>();
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned if the values operand has more than one item
+   */
+  @Test
+  public void testFixValuesWithValuesListMoreThanOneItem()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("", ""));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned if the values operand is not valid json
+   */
+  @Test
+  public void testFixValuesWithValuesNotValidJson()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("{ not valid"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned if the values operand is not a JSON object
+   */
+  @Test
+  public void testFixValuesWithValuesNotJsonObject()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("[ \"array\", \"not\", \"object\" ]"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned if fieldName contains multiple dots (sub-sub-attribute)
+   */
+  @Test
+  public void testFixValuesWithFieldNameWithMoreThanOneDot()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("{ \"first.second.third\": \"value\" }"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the original values is returned in simple extension cases
+   */
+  @Test
+  public void testFixValuesWithExtensionWithoutWorkaround()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("{ \"schemas\": [ \"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\" ], \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\": { \"costCenter\": \"1234\" } }"));
+
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertEquals(values, valuesResult);
+  }
+
+  /**
+   * verifies that the workaround is applied with extension
+   */
+  @Test
+  public void testFixValuesWithExtensionWithWorkaroundApplied()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+    final List<String> values = new ArrayList<>(Arrays.asList("{ \"schemas\": [ \"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\" ], \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\": { \"manager.displayName\": \"captain\" } }"));
+    final List<String> expectedValues = new ArrayList<>(Arrays.asList("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\"],\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\":{\"manager\":{\"displayName\":\"captain\"}}}"));
+
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertIterableEquals(expectedValues, valuesResult);
+  }
+
+
+  /**
+   * verifies that the workaround is applied on direct resource and fully qualified enterprise user
+   */
+  @Test
+  public void testFixValuesWithUserAndEnterpriseUser()
+  {
+    final PatchOp patchOp = PatchOp.REPLACE;
+
+    final List<String> values = new ArrayList<>(Arrays.asList("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\"],\"name.givenName\":\"goldfish\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\":{\"costCenter\":\"1234\"}}"));
+    final List<String> expectedValues = new ArrayList<>(Arrays.asList("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\"],\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\":{\"costCenter\":\"1234\"},\"name\":{\"givenName\":\"goldfish\"}}"));
+
+    MsAzurePatchReplaceWorkaroundHandler msAzurePatchReplaceWorkaroundHandler = new MsAzurePatchReplaceWorkaroundHandler(patchOp,
+                                                                                                                         values);
+    List<String> valuesResult = msAzurePatchReplaceWorkaroundHandler.fixValues();
+
+    Assertions.assertIterableEquals(expectedValues, valuesResult);
+  }
+
+
+}
+


### PR DESCRIPTION
… notation

This is a workaround in order to handle the broken patch requests of Microsoft Azure. Azure
sends illegal patch-remove requests that looks as follows:

PATCH /scim/Users/2752513
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ],
    "Operations": [
        {
            "op": "replace",
            "value": {
                "name.givenName": "captain",
                "name.familyName": "goldfish"
            }
        }
    ]
}

the value in the request must not be present. Instead the request should look like this:

PATCH /scim/Users/2752513
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ],
    "Operations": [
        {
            "op": "replace",
            "value": {
                "name": {
                    "givenName": "captain",
                    "familyName": "goldfish"
                }
            }
        }
    ]
}

Fixes 267