### PR TITLE
Make RequestSchemaValidator return HTTP status 400 instead of 500 on validation failure

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/AbstractSchemaValidator.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/AbstractSchemaValidator.java
@@ -55,6 +55,12 @@ public abstract class AbstractSchemaValidator
   protected abstract Optional<JsonNode> validateAttribute(SchemaAttribute schemaAttribute, JsonNode attribute);
 
   /**
+   * the http status code to use in the {@link DocumentValidationException} if the validation fails. Should be
+   * 400 (bad request) for requests and 500 (internal server error) for responses
+   */
+  protected abstract int getHttpStatusCode();
+
+  /**
    * checks the given document against the schema definition of the {@link #resourceType}
    *
    * @param resource the document that should be validated
@@ -72,7 +78,7 @@ public abstract class AbstractSchemaValidator
     {
       Throwable cause = ExceptionUtils.getRootCause(ex);
       String errorMessage = Optional.ofNullable(cause).map(Throwable::getMessage).orElse(ex.getMessage());
-      throw new DocumentValidationException(errorMessage, ex, null, null);
+      throw new DocumentValidationException(errorMessage, ex, getHttpStatusCode(), null);
     }
   }
 

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/MetaSchemaValidator.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/MetaSchemaValidator.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
+import de.captaingoldfish.scim.sdk.common.constants.HttpStatus;
 import de.captaingoldfish.scim.sdk.common.resources.base.ScimArrayNode;
 import de.captaingoldfish.scim.sdk.common.resources.base.ScimObjectNode;
 import de.captaingoldfish.scim.sdk.common.resources.base.ScimTextNode;
@@ -62,5 +63,14 @@ public class MetaSchemaValidator extends AbstractSchemaValidator
   protected Optional<JsonNode> validateAttribute(SchemaAttribute schemaAttribute, JsonNode attribute)
   {
     return MetaAttributeValidator.validateAttribute(schemaAttribute, attribute);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected int getHttpStatusCode()
+  {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
   }
 }

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/RequestSchemaValidator.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/RequestSchemaValidator.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import de.captaingoldfish.scim.sdk.common.constants.HttpStatus;
 import de.captaingoldfish.scim.sdk.common.constants.enums.HttpMethod;
 import de.captaingoldfish.scim.sdk.common.resources.ServiceProvider;
 import de.captaingoldfish.scim.sdk.common.schemas.SchemaAttribute;
@@ -68,5 +69,14 @@ public class RequestSchemaValidator extends AbstractSchemaValidator
       validationContext.addExceptionMessages(ex);
       return Optional.empty();
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected int getHttpStatusCode()
+  {
+    return HttpStatus.BAD_REQUEST;
   }
 }

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/ResponseSchemaValidator.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/ResponseSchemaValidator.java
@@ -6,6 +6,7 @@ import java.util.function.BiFunction;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import de.captaingoldfish.scim.sdk.common.constants.HttpStatus;
 import de.captaingoldfish.scim.sdk.common.resources.ServiceProvider;
 import de.captaingoldfish.scim.sdk.common.schemas.SchemaAttribute;
 
@@ -65,5 +66,14 @@ public class ResponseSchemaValidator extends AbstractSchemaValidator
                                                         attributesList,
                                                         excludedAttributesList,
                                                         referenceUrlSupplier);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected int getHttpStatusCode()
+  {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/384 using the suggested solution. This is the exact same implementation as the one already present in the `*ResourceValidator` hierarchy.

I've checked the tests and it looks like there are none testing this particular functionality. As this is a rather small and straightforward fix, I dare submitting this without adding any 🙃 