### PR TITLE
NO_CONTENT (204) is also a valid response code when using the patch operation.

### DIFF
--- a/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
+++ b/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
@@ -85,7 +85,7 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
   @Override
   protected boolean isExpectedResponseCode(int httpStatus)
   {
-    return HttpStatus.OK == httpStatus;
+    return HttpStatus.OK == httpStatus || HttpStatus.NO_CONTENT == httpStatus;
   }
 
   /**


### PR DESCRIPTION
See RFC 7644 section-3.5.2:
https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2

> On successful completion, the server either MUST return a 200 OK
   response code and the entire resource within the response body,
   subject to the "attributes" query parameter (see [Section 3.9](https://datatracker.ietf.org/doc/html/rfc7644#section-3.9)), or MAY
   return HTTP status code 204 (No Content) and the appropriate response
   headers for a successful PATCH request.  The server MUST return a 200
   OK if the "attributes" parameter is specified in the request.