### PR TITLE
[Fixes #629] Lenient content type header checking

### DIFF
--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/constants/HttpHeader.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/constants/HttpHeader.java
@@ -18,6 +18,8 @@ public final class HttpHeader
 
   public static final String SCIM_CONTENT_TYPE = "application/scim+json";
 
+  public static final String APPLICATION_JSON_CONTENT_TYPE = "application/json";
+
   public static final String LOCATION_HEADER = "Location";
 
   public static final String E_TAG_HEADER = "ETag";

--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/ServiceProvider.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/ServiceProvider.java
@@ -139,6 +139,7 @@ public class ServiceProvider extends ResourceNode
     this.caseInsensitiveValidation = caseInsensitiveValidation;
     this.useDefaultValuesOnRequest = useDefaultValuesOnRequest;
     this.useDefaultValuesOnResponse = useDefaultValuesOnResponse;
+    this.lenientContentTypeChecking = lenientContentTypeChecking;
     this.ignoreRequiredAttributesOnResponse = Optional.ofNullable(ignoreRequiredAttributesOnResponse).orElse(true);
     this.ignoreRequiredExtensionsOnResponse = Optional.ofNullable(ignoreRequiredExtensionsOnResponse).orElse(true);
   }

--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/ServiceProvider.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/resources/ServiceProvider.java
@@ -85,6 +85,9 @@ public class ServiceProvider extends ResourceNode
   @Setter
   private boolean ignoreRequiredExtensionsOnResponse = false;
 
+  @Getter
+  private boolean lenientContentTypeChecking = false;
+
   /**
    * @param documentationUri the URL to the documentation of the application
    * @param patchConfig the patch configuration
@@ -114,7 +117,8 @@ public class ServiceProvider extends ResourceNode
                          boolean useDefaultValuesOnRequest,
                          boolean useDefaultValuesOnResponse,
                          Boolean ignoreRequiredAttributesOnResponse,
-                         Boolean ignoreRequiredExtensionsOnResponse)
+                         Boolean ignoreRequiredExtensionsOnResponse,
+                         boolean lenientContentTypeChecking)
   {
     setSchemas(Arrays.asList(SchemaUris.SERVICE_PROVIDER_CONFIG_URI));
     setDocumentationUri(documentationUri);

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/BulkEndpoint.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/BulkEndpoint.java
@@ -267,10 +267,13 @@ class BulkEndpoint
   {
     HttpMethod httpMethod = operation.getMethod();
     Map<String, String> httpHeaders = getHttpHeadersForBulk(operation);
+    boolean lenientContentTypeChecking = getServiceProvider().isLenientContentTypeChecking();
+
     UriInfos operationUriInfo = UriInfos.getRequestUrlInfos(getResourceTypeFactory(),
                                                             baseUri + operation.getPath(),
                                                             httpMethod,
-                                                            httpHeaders);
+                                                            httpHeaders,
+                                                            lenientContentTypeChecking);
     operationUriInfo.getQueryParameters().putAll(originalQueryParams);
     String id = Optional.ofNullable(operationUriInfo.getResourceId()).map(resourceId -> "/" + resourceId).orElse("");
     String location = baseUri + operationUriInfo.getResourceEndpoint() + id;
@@ -405,6 +408,7 @@ class BulkEndpoint
                                                                                       Map<String, String> httpHeaders,
                                                                                       Context context)
   {
+    boolean lenientContentTypeChecking = getServiceProvider().isLenientContentTypeChecking();
     return (resourceId, resourceType) -> {
       UriInfos uriInfos = UriInfos.getRequestUrlInfos(getResourceTypeFactory(),
                                                       String.format("%s%s/%s",
@@ -412,7 +416,8 @@ class BulkEndpoint
                                                                     resourceType.getEndpoint(),
                                                                     resourceId),
                                                       HttpMethod.GET,
-                                                      httpHeaders);
+                                                      httpHeaders,
+                                                      lenientContentTypeChecking);
       return resourceEndpoint.resolveRequest(uriInfos.getHttpMethod(), null, uriInfos, doBeforeExecution, context);
     };
   }

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpoint.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpoint.java
@@ -175,10 +175,15 @@ public final class ResourceEndpoint extends ResourceEndpointHandler
                                     Context context)
   {
     ScimResponse scimResponse;
+    boolean lenientContentTypeChecking = getServiceProvider().isLenientContentTypeChecking();
 
     handleScimRequest: try
     {
-      UriInfos uriInfos = UriInfos.getRequestUrlInfos(getResourceTypeFactory(), requestUrl, httpMethod, httpHeaders);
+      UriInfos uriInfos = UriInfos.getRequestUrlInfos(getResourceTypeFactory(),
+                                                      requestUrl,
+                                                      httpMethod,
+                                                      httpHeaders,
+                                                      lenientContentTypeChecking);
       if (EndpointPaths.BULK.equals(uriInfos.getResourceEndpoint()))
       {
         BulkEndpoint bulkEndpoint = new BulkEndpoint(this, getServiceProvider(), getResourceTypeFactory(),

--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/utils/UriInfos.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/utils/UriInfos.java
@@ -273,6 +273,7 @@ public class UriInfos
         else if (lenientContentTypeChecking && hasApplicationJsonContentType)
         {
           // accepting applicationJson
+          log.debug("Accepting Content-Type: 'application/json' as specified by to 'lenientContentTypeChecking' setting.");
         }
         else
         {

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ETagRequestTests.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ETagRequestTests.java
@@ -83,7 +83,8 @@ public class ETagRequestTests
                                                                                                     .map(s -> "/" + s)
                                                                                                     .orElse(""),
                                                     httpMethod,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     return context;
   }
 

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointHandlerTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointHandlerTest.java
@@ -179,7 +179,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
                                                                                    .map(s -> "/" + s)
                                                                                    .orElse(""),
                                                     httpMethod,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     return context;
   }
 
@@ -2085,7 +2086,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
     context.setUriInfos(UriInfos.getRequestUrlInfos(resourceTypeFactory,
                                                     getBaseUrlSupplier().get() + "/Users/" + user.getId().get(),
                                                     HttpMethod.PATCH,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     ScimResponse scimResponse = Assertions.assertDoesNotThrow(() -> {
       return resourceEndpointHandler.patchResource(EndpointPaths.USERS,
                                                    id,
@@ -2180,7 +2182,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
     context.setUriInfos(UriInfos.getRequestUrlInfos(resourceTypeFactory,
                                                     getBaseUrlSupplier().get() + "/Users/" + user.getId().get(),
                                                     HttpMethod.PATCH,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     ScimResponse scimResponse = resourceEndpointHandler.patchResource("/Users",
                                                                       user.getId().get(),
                                                                       patchOpRequest.toString(),
@@ -2314,7 +2317,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
     context.setUriInfos(UriInfos.getRequestUrlInfos(resourceTypeFactory,
                                                     getBaseUrlSupplier().get() + "/Users/" + createdUser.getId().get(),
                                                     HttpMethod.PATCH,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
 
     List<DynamicTest> dynamicTests = new ArrayList<>();
     /* ************************************************************************************************************/
@@ -3068,7 +3072,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
     context.setUriInfos(UriInfos.getRequestUrlInfos(resourceTypeFactory,
                                                     getBaseUrlSupplier().get() + "/Users/" + userId,
                                                     HttpMethod.PATCH,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
 
     ScimResponse scimResponse = resourceEndpointHandler.getResource(endpoint,
                                                                     userId,
@@ -3121,7 +3126,8 @@ public class ResourceEndpointHandlerTest implements FileReferences
     context.setUriInfos(UriInfos.getRequestUrlInfos(resourceTypeFactory,
                                                     getBaseUrlSupplier().get() + "/Users/" + readUser.getId().get(),
                                                     HttpMethod.PATCH,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     ScimResponse scimResponse = resourceEndpointHandler.updateResource(endpoint,
                                                                        readUser.getId().get(),
                                                                        updateUser.toString(),

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/ResourceEndpointTest.java
@@ -162,7 +162,8 @@ public class ResourceEndpointTest extends AbstractBulkTest implements FileRefere
                                                                                   .map(s -> "/" + s)
                                                                                   .orElse(""),
                                                     httpMethod,
-                                                    httpHeaders));
+                                                    httpHeaders,
+                                                    false));
     return context;
   }
 

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/utils/UriInfosTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/utils/UriInfosTest.java
@@ -194,8 +194,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies the scim content-type is always allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/scim+json", "PUT,application/scim+json", "PATCH,application/scim+json"})
@@ -219,8 +218,8 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies the application/json content type is allowed if content-type checking is configured to be lenient,
+   * disallowed otherwise.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/json", "PUT,application/json", "PATCH,application/json"})
@@ -244,8 +243,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies an amepty or missing content type is never allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,", "PUT,", "PATCH,"})
@@ -269,8 +267,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies content-types other than application/scim+json and application/json are never allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/xml", "POST,text/plain", "POST,text/xml", "PUT,application/xml", "PUT,text/plain",
@@ -295,8 +292,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies the scim content-type is always allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/scim+json"})
@@ -320,8 +316,8 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies the application/json content type is allowed if content-type checking is configured to be lenient,
+   * disallowed otherwise.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/json"})
@@ -345,8 +341,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies an amepty or missing content type is never allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,"})
@@ -370,8 +365,7 @@ public class UriInfosTest
   }
 
   /**
-   * will verify that calling the users endpoint with post, put or patch and an invalid content-type results in
-   * a {@link BadRequestException}s
+   * Verifies content-types other than application/scim+json and application/json are never allowed.
    */
   @ParameterizedTest
   @CsvSource({"POST,application/xml", "POST,text/plain", "POST,text/xml"})


### PR DESCRIPTION
- Adds the ability to configure the SCIM server configuration to check the content type header leniently, meaning application/json is also accepted, in addition to applicationscim+json. 
- This is supported by RFC-7644, which says 

> Interoperability considerations:  The "application/scim+json" media
>       type is intended to identify JSON structure data that conforms to
>       the SCIM protocol and schema specifications.  Older versions of
>       SCIM are known to informally use "application/json".

and also (regarding the Accept header):

> Service providers MUST support the "Accept" header
>    "Accept: application/scim+json" and SHOULD support the header
>    "Accept: application/json", both of which specify JSON documents
>    conforming to [[RFC7159](https://datatracker.ietf.org/doc/html/rfc7159)].  The format defaults to
>    "application/scim+json" if no format is specified.

This also fits in with general good practices, which suggest to be lenient with regards to your input, but strict with regards to your output.

- Also reworked the UriInfos test slightly to better separate the different cases for content type validation.