### PR TITLE
Support String to boolean conversion for Upper-Case starting booleans

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/SimpleAttributeValidator.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/schemas/validation/SimpleAttributeValidator.java
@@ -177,7 +177,7 @@ class SimpleAttributeValidator
       switch (schemaAttribute.getType())
       {
         case BOOLEAN:
-          boolean isBoolString = Arrays.asList("true", "false").contains(valueNode.textValue());
+          boolean isBoolString = Arrays.asList("true", "false", "True", "False").contains(valueNode.textValue());
           if (isBoolString)
           {
             return Optional.of(new ScimBooleanNode(schemaAttribute, Boolean.parseBoolean(valueNode.textValue())));


### PR DESCRIPTION
This is required to support Microsoft SCIM Validation - role.primary value is string: "True" instead of boolean.  See https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility for more details