### PR TITLE
Fix NullPointerException in MsAzurePatchComplexValueRebuilder for empty String

### DIFF
--- a/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/workarounds/msazure/MsAzurePatchComplexValueRebuilder.java
+++ b/scim-sdk-server/src/main/java/de/captaingoldfish/scim/sdk/server/patch/workarounds/msazure/MsAzurePatchComplexValueRebuilder.java
@@ -139,7 +139,7 @@ public class MsAzurePatchComplexValueRebuilder extends PatchWorkaround
         continue;
       }
 
-      if (jsonNode.isObject() || jsonNode.isArray())
+      if (jsonNode != null && (jsonNode.isObject() || jsonNode.isArray()))
       {
         log.trace("[MS Azure complex-patch-path-value workaround] ignoring non-simple-value for attribute {}",
                   schemaAttribute.getScimNodeName());


### PR DESCRIPTION
Fixes #652

Fixes NullPointerException when setting complex object to an empty string with `MsAzureWorkaround` enabled for Patch Configuration:
```
{
  "schemas": ["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
  "Operations": {
    "op": "replace",
    "path": "manager",
    "value": ""
  }
}
```