### PR TITLE
Fix path-based scalar PATCH values for setValue/setValues

### DIFF
--- a/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/ScimClientConfig.java
+++ b/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/ScimClientConfig.java
@@ -122,6 +122,16 @@ public class ScimClientConfig
   private boolean useLowerCaseInFilterComparators;
 
   /**
+   * If enabled, values of pathless PATCH operations are normalized before the request is sent to ensure a
+   * SCIM-compliant wire representation.
+   * <p>
+   * Enabling this option requires an additional iteration over all PATCH operations before transmission. For
+   * requests containing a large number of operations, this introduces a small additional processing overhead.
+   * </p>
+   */
+  private boolean normalizePathlessPatchValues;
+
+  /**
    * a string value describing the TLS version that is used for SSLContexts
    */
   private String tlsVersion;
@@ -188,6 +198,7 @@ public class ScimClientConfig
                           BasicAuth basicAuth,
                           ConfigManipulator configManipulator,
                           boolean useLowerCaseInFilterComparators,
+                          boolean normalizePathlessPatchOperations,
                           Map<String, String> expectedHttpResponseHeaders,
                           String tlsVersion,
                           HttpClientBuilder httpClientBuilder,
@@ -207,6 +218,7 @@ public class ScimClientConfig
     this.basicAuth = basicAuth;
     this.configManipulator = configManipulator;
     this.useLowerCaseInFilterComparators = useLowerCaseInFilterComparators;
+    this.normalizePathlessPatchValues = normalizePathlessPatchOperations;
     this.expectedHttpResponseHeaders = expectedHttpResponseHeaders;
     this.tlsVersion = Optional.ofNullable(tlsVersion).map(StringUtils::stripToNull).orElse("TLSv1.2");
     this.httpClientBuilder = httpClientBuilder;

--- a/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
+++ b/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpPatch;
@@ -174,6 +175,18 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
     return new PatchOpRequest(operations).toString();
   }
 
+  @Override
+  public <R extends ServerResponse<T>> R sendRequest()
+  {
+    return super.sendRequest();
+  }
+
+  @Override
+  public <R extends ServerResponse<T>> R sendRequest(Map<String, String> headers)
+  {
+    return super.sendRequest(headers);
+  }
+
   /**
    * this method will split the operations into the appropriate number of max operations per requests and will
    * send all patch-requests one by one to the remote SCIM provider.
@@ -202,6 +215,10 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
     for ( int i = 0 ; i < requestOperations.size() ; i++ )
     {
       List<PatchRequestOperation> operationList = requestOperations.get(i);
+      if (scimClientConfig.isNormalizePathlessPatchValues())
+      {
+        normalizePathlessOperations(operationList);
+      }
 
       HttpUriRequest request = getHttpUriRequest(operationList);
       request.setHeader(HttpHeader.CONTENT_TYPE_HEADER, HttpHeader.SCIM_CONTENT_TYPE);
@@ -246,6 +263,49 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
                                                             operations.size())));
     }
     return splittedOperationList;
+  }
+
+  /**
+   * Normalizes pathless PATCH operations before they are sent to the remote SCIM provider.
+   * <p>
+   * A pathless PATCH operation addresses a set of resource attributes and therefore expects its value to be
+   * represented as a JSON object. If such an object is wrapped in a singleton array, the array is unwrapped
+   * before transmission.
+   * </p>
+   * <p>
+   * Structured values represented as JSON strings are materialized through
+   * {@link PatchRequestOperation#getValue()} before the normalization is applied.
+   * </p>
+   *
+   * @param requestOperations the PATCH operations to normalize
+   */
+  private void normalizePathlessOperations(List<PatchRequestOperation> requestOperations)
+  {
+    for ( PatchRequestOperation operation : requestOperations )
+    {
+      if (operation.getPath().isPresent())
+      {
+        continue;
+      }
+
+      Optional<JsonNode> optionalValue = operation.getValue();
+      if (!optionalValue.isPresent())
+      {
+        continue;
+      }
+
+      JsonNode value = optionalValue.get();
+      if (!value.isArray() || value.size() != 1)
+      {
+        continue;
+      }
+
+      JsonNode arrayValue = value.get(0);
+      if (arrayValue.isObject())
+      {
+        operation.setValueNode(arrayValue);
+      }
+    }
   }
 
   /**
@@ -330,7 +390,7 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
      * sets a list of nodes that might be a simple text-nodes, json objects or json arrays that will then be added
      * into an array node.
      *
-     * @param valueNode list of simple text-nodes, json objects or json arrays
+     * @param valueNodes list of simple text-nodes, json objects or json arrays
      */
     public PatchOperationBuilder<T> valueNodes(List<? extends JsonNode> valueNodes)
     {

--- a/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/ListBuilderTest.java
+++ b/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/ListBuilderTest.java
@@ -418,9 +418,6 @@ public class ListBuilderTest extends HttpServerMockup
               "4946,50,false", "4500,500,false"})
   public void testSendListGetAllRequest(Long startIndex, Integer count, boolean useGet)
   {
-    System.out.println("USER COUNT BEFORE LIST TEST: "
-                       + ((UserHandler)scimConfig.getUserResourceType().getResourceHandlerImpl()).getInMemoryMap()
-                                                                                                 .size());
     final String sortBy = "username";
     final SortOrder sortOrder = SortOrder.DESCENDING;
     final String[] attributes = new String[]{"username", "meta.created"};

--- a/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilderWireFormatTest.java
+++ b/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilderWireFormatTest.java
@@ -1,0 +1,102 @@
+package de.captaingoldfish.scim.sdk.client.builder;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import de.captaingoldfish.scim.sdk.client.ScimClientConfig;
+import de.captaingoldfish.scim.sdk.client.http.ScimHttpClient;
+import de.captaingoldfish.scim.sdk.common.constants.EndpointPaths;
+import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
+import de.captaingoldfish.scim.sdk.common.resources.User;
+import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
+
+
+/**
+ * Verifies the wire format of patch requests built through the public {@link PatchBuilder} API. Path-based
+ * single values must be serialized as scalars and not as singleton arrays in order to stay RFC 7644
+ * compliant.
+ *
+ * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+ */
+public class PatchBuilderWireFormatTest
+{
+
+  private PatchBuilder<User> createPatchBuilder()
+  {
+    ScimHttpClient scimHttpClient = new ScimHttpClient(ScimClientConfig.builder().build());
+    return new PatchBuilder<>("http://localhost:8180/scim/v2", EndpointPaths.USERS, "user-id", User.class,
+                              scimHttpClient);
+  }
+
+  /**
+   * <pre>{@code
+   * {"op":"replace","path":"preferredLanguage","value":"de"}
+   * }</pre>
+   */
+  @Test
+  @DisplayName("Path-based scalar valueNode is serialized as a scalar")
+  public void testPathBasedScalarValueNodeIsSerializedAsScalar()
+  {
+    PatchBuilder<User> patchBuilder = createPatchBuilder();
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("preferredLanguage").valueNode(TextNode.valueOf("de")).build();
+
+    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(valueNode.isTextual(), patchBuilder.getResource());
+    Assertions.assertEquals("de", valueNode.textValue());
+  }
+
+  /**
+   * Numeric strings such as {@code "67890"} must keep their JSON string type and must not be converted into
+   * numbers during serialization or value access.
+   *
+   * <pre>{@code
+   * {"op":"replace","path":"preferredLanguage","value":"67890"}
+   * }</pre>
+   */
+  @Test
+  @DisplayName("Numeric string values keep their string type")
+  public void testNumericStringValueKeepsStringType()
+  {
+    PatchBuilder<User> patchBuilder = createPatchBuilder();
+    patchBuilder.addOperation()
+                .op(PatchOp.REPLACE)
+                .path("preferredLanguage")
+                .valueNode(TextNode.valueOf("67890"))
+                .build();
+
+    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(valueNode.isTextual(), patchBuilder.getResource());
+    Assertions.assertEquals("67890", valueNode.textValue());
+  }
+
+  /**
+   * Multiple values must remain an array since multi-valued attributes require the array representation.
+   *
+   * <pre>{@code
+   * {"op":"replace","path":"tags","value":["tag-a","tag-b"]}
+   * }</pre>
+   */
+  @Test
+  @DisplayName("Multiple values are serialized as an array")
+  public void testMultipleValuesAreSerializedAsArray()
+  {
+    PatchBuilder<User> patchBuilder = createPatchBuilder();
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("tags").values(Arrays.asList("tag-a", "tag-b")).build();
+
+    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(valueNode.isArray(), patchBuilder.getResource());
+    Assertions.assertEquals(2, valueNode.size());
+  }
+
+  private JsonNode getSerializedValue(String patchRequestResource)
+  {
+    JsonNode patchRequest = JsonHelper.readJsonDocument(patchRequestResource);
+    return patchRequest.get("Operations").get(0).get("value");
+  }
+}

--- a/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilderWireFormatTest.java
+++ b/scim-sdk-client/src/test/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilderWireFormatTest.java
@@ -1,102 +1,852 @@
 package de.captaingoldfish.scim.sdk.client.builder;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import de.captaingoldfish.scim.sdk.client.ScimClientConfig;
+import de.captaingoldfish.scim.sdk.client.http.HttpResponse;
 import de.captaingoldfish.scim.sdk.client.http.ScimHttpClient;
+import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
 import de.captaingoldfish.scim.sdk.common.constants.EndpointPaths;
+import de.captaingoldfish.scim.sdk.common.constants.HttpHeader;
+import de.captaingoldfish.scim.sdk.common.constants.HttpStatus;
 import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
+import de.captaingoldfish.scim.sdk.common.request.PatchOpRequest;
+import de.captaingoldfish.scim.sdk.common.request.PatchRequestOperation;
 import de.captaingoldfish.scim.sdk.common.resources.User;
 import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
 
 
 /**
- * Verifies the wire format of patch requests built through the public {@link PatchBuilder} API. Path-based
- * single values must be serialized as scalars and not as singleton arrays in order to stay RFC 7644
- * compliant.
+ * Verifies the wire format of PATCH requests immediately before they are sent to the remote SCIM provider.
+ * <p>
+ * {@link PatchRequestOperation} instances should preserve the representation explicitly supplied by the
+ * caller while they are being built. Optional normalization of pathless PATCH operations is applied only
+ * immediately before transmission if enabled through {@link ScimClientConfig}.
+ * </p>
+ * <p>
+ * Path-based operations must preserve the JSON type explicitly supplied by the caller regardless of whether
+ * pathless PATCH normalization is enabled. Pathless operations containing an already valid object value must
+ * likewise remain unchanged.
+ * </p>
+ * <p>
+ * If pathless PATCH normalization is enabled, a singleton array containing a resource object is unwrapped
+ * immediately before transmission. If normalization is disabled, the representation supplied by the caller is
+ * transmitted unchanged.
+ * </p>
  *
  * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
  */
 public class PatchBuilderWireFormatTest
 {
 
-  private PatchBuilder<User> createPatchBuilder()
-  {
-    ScimHttpClient scimHttpClient = new ScimHttpClient(ScimClientConfig.builder().build());
-    return new PatchBuilder<>("http://localhost:8180/scim/v2", EndpointPaths.USERS, "user-id", User.class,
-                              scimHttpClient);
-  }
+  private ScimHttpClient scimHttpClient;
+
+  private PatchBuilder<User> patchBuilder;
 
   /**
-   * <pre>{@code
-   * {"op":"replace","path":"preferredLanguage","value":"de"}
-   * }</pre>
+   * Initializes the PATCH builder and mocked HTTP client with the requested pathless PATCH normalization
+   * setting.
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH operations should be normalized before
+   *          transmission
    */
-  @Test
-  @DisplayName("Path-based scalar valueNode is serialized as a scalar")
-  public void testPathBasedScalarValueNodeIsSerializedAsScalar()
+  private void initialize(boolean normalizePathlessPatchOperations)
   {
-    PatchBuilder<User> patchBuilder = createPatchBuilder();
-    patchBuilder.addOperation().op(PatchOp.REPLACE).path("preferredLanguage").valueNode(TextNode.valueOf("de")).build();
+    ScimClientConfig scimClientConfig = ScimClientConfig.builder()
+                                                        .normalizePathlessPatchOperations(normalizePathlessPatchOperations)
+                                                        .build();
+    scimHttpClient = Mockito.spy(new ScimHttpClient(scimClientConfig));
 
-    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
-    Assertions.assertTrue(valueNode.isTextual(), patchBuilder.getResource());
-    Assertions.assertEquals("de", valueNode.textValue());
+    HttpResponse httpResponse = HttpResponse.builder()
+                                            .httpStatusCode(HttpStatus.NO_CONTENT)
+                                            .responseHeaders(Collections.singletonMap(HttpHeader.CONTENT_TYPE_HEADER,
+                                                                                      HttpHeader.SCIM_CONTENT_TYPE))
+                                            .build();
+
+    Mockito.doReturn(httpResponse).when(scimHttpClient).sendRequest(Mockito.any(HttpUriRequest.class));
+
+    patchBuilder = new PatchBuilder<>("http://localhost:8180/scim/v2", EndpointPaths.USERS, "user-id", User.class,
+                                      scimHttpClient);
   }
 
   /**
-   * Numeric strings such as {@code "67890"} must keep their JSON string type and must not be converted into
-   * numbers during serialization or value access.
+   * Verifies that an explicitly supplied textual value remains a scalar when a path is present. The result must
+   * be independent of pathless PATCH normalization.
    *
    * <pre>{@code
-   * {"op":"replace","path":"preferredLanguage","value":"67890"}
+   * {
+   *   "op": "replace",
+   *   "path": "preferredLanguage",
+   *   "value": "de"
+   * }
    * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
    */
-  @Test
-  @DisplayName("Numeric string values keep their string type")
-  public void testNumericStringValueKeepsStringType()
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based textual valueNode is sent unchanged")
+  public void testPathBasedTextualValueNodeIsSentUnchanged(boolean normalizePathlessPatchOperations)
   {
-    PatchBuilder<User> patchBuilder = createPatchBuilder();
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("preferredLanguage").valueNode(TextNode.valueOf("de")).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isTextual(), value.toPrettyString());
+    Assertions.assertEquals("de", value.textValue());
+  }
+
+  /**
+   * Verifies that a single value supplied through the convenience {@code value} method is transmitted as a
+   * scalar when a path is present. The result must be independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "preferredLanguage",
+   *   "value": "de"
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based single value is sent as scalar")
+  public void testPathBasedSingleValueIsSentAsScalar(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("preferredLanguage").value("de").build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isTextual(), value.toPrettyString());
+    Assertions.assertEquals("de", value.textValue());
+  }
+
+  /**
+   * Numeric strings such as {@code "67890"} must retain their JSON string type and must not be converted into
+   * numeric JSON values. The result must be independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "preferredLanguage",
+   *   "value": "67890"
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based numeric string keeps its string type")
+  public void testPathBasedNumericStringKeepsStringType(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
     patchBuilder.addOperation()
                 .op(PatchOp.REPLACE)
                 .path("preferredLanguage")
                 .valueNode(TextNode.valueOf("67890"))
                 .build();
 
-    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
-    Assertions.assertTrue(valueNode.isTextual(), patchBuilder.getResource());
-    Assertions.assertEquals("67890", valueNode.textValue());
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isTextual(), value.toPrettyString());
+    Assertions.assertEquals("67890", value.textValue());
   }
 
   /**
-   * Multiple values must remain an array since multi-valued attributes require the array representation.
+   * Verifies that a numeric JSON value retains its type when a path is present. The result must be independent
+   * of pathless PATCH normalization.
    *
    * <pre>{@code
-   * {"op":"replace","path":"tags","value":["tag-a","tag-b"]}
+   * {
+   *   "op": "replace",
+   *   "path": "someNumber",
+   *   "value": 42
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based numeric value is sent unchanged")
+  public void testPathBasedNumericValueIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("someNumber").valueNode(IntNode.valueOf(42)).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isIntegralNumber(), value.toPrettyString());
+    Assertions.assertEquals(42, value.intValue());
+  }
+
+  /**
+   * Verifies that a boolean JSON value retains its type when a path is present. The result must be independent
+   * of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "active",
+   *   "value": false
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based boolean value is sent unchanged")
+  public void testPathBasedBooleanValueIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("active").valueNode(BooleanNode.FALSE).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isBoolean(), value.toPrettyString());
+    Assertions.assertFalse(value.booleanValue());
+  }
+
+  /**
+   * Verifies that an object supplied for a path-based operation remains an object. The result must be
+   * independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "name",
+   *   "value": {
+   *     "givenName": "Link"
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based object is sent unchanged")
+  public void testPathBasedObjectIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    ObjectNode name = JsonNodeFactory.instance.objectNode();
+    name.put("givenName", "Link");
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("name").valueNode(name).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isObject(), value.toPrettyString());
+    Assertions.assertEquals("Link", value.get("givenName").textValue());
+  }
+
+  /**
+   * Verifies that an explicitly supplied singleton array remains an array when a path is present.
+   * <p>
+   * A singleton array may represent a multi-valued SCIM attribute containing exactly one value. Its
+   * representation must therefore not be changed based on the number of contained elements.
+   * </p>
+   *
+   * <pre>{@code
+   * {
+   *   "op": "add",
+   *   "path": "roles",
+   *   "value": ["ADMIN"]
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based singleton scalar array is sent unchanged")
+  public void testPathBasedSingletonScalarArrayIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    ArrayNode roles = JsonNodeFactory.instance.arrayNode();
+    roles.add("ADMIN");
+
+    patchBuilder.addOperation().op(PatchOp.ADD).path("roles").valueNode(roles).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isArray(), value.toPrettyString());
+    Assertions.assertEquals(1, value.size());
+    Assertions.assertEquals("ADMIN", value.get(0).textValue());
+  }
+
+  /**
+   * Verifies that a singleton array created through the {@code valueNodes} convenience method remains an array
+   * when a path is present. The result must be independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "add",
+   *   "path": "roles",
+   *   "value": ["ADMIN"]
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based singleton valueNodes array is sent unchanged")
+  public void testPathBasedSingletonValueNodesArrayIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation()
+                .op(PatchOp.ADD)
+                .path("roles")
+                .valueNodes(Collections.singletonList(TextNode.valueOf("ADMIN")))
+                .build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isArray(), value.toPrettyString());
+    Assertions.assertEquals(1, value.size());
+    Assertions.assertEquals("ADMIN", value.get(0).textValue());
+  }
+
+  /**
+   * Verifies that a singleton array containing an object remains an array when a path is present. The result
+   * must be independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "add",
+   *   "path": "emails",
+   *   "value": [{
+   *     "value": "link@hyrule.example",
+   *     "type": "work"
+   *   }]
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based singleton object array is sent unchanged")
+  public void testPathBasedSingletonObjectArrayIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    ObjectNode email = JsonNodeFactory.instance.objectNode();
+    email.put("value", "link@hyrule.example");
+    email.put("type", "work");
+
+    ArrayNode emails = JsonNodeFactory.instance.arrayNode();
+    emails.add(email);
+
+    patchBuilder.addOperation().op(PatchOp.ADD).path("emails").valueNode(emails).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isArray(), value.toPrettyString());
+    Assertions.assertEquals(1, value.size());
+    Assertions.assertTrue(value.get(0).isObject(), value.toPrettyString());
+    Assertions.assertEquals("link@hyrule.example", value.get(0).get("value").textValue());
+    Assertions.assertEquals("work", value.get(0).get("type").textValue());
+  }
+
+  /**
+   * Verifies that an array containing multiple values remains unchanged when a path is present. The result must
+   * be independent of pathless PATCH normalization.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "tags",
+   *   "value": ["tag-a", "tag-b"]
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based multiple values are sent as array")
+  public void testPathBasedMultipleValuesAreSentAsArray(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).path("tags").values(Arrays.asList("tag-a", "tag-b")).build();
+
+    JsonNode value = sendAndGetValue();
+
+    Assertions.assertTrue(value.isArray(), value.toPrettyString());
+    Assertions.assertEquals(2, value.size());
+    Assertions.assertEquals("tag-a", value.get(0).textValue());
+    Assertions.assertEquals("tag-b", value.get(1).textValue());
+  }
+
+  /**
+   * Verifies that an already valid object supplied for a pathless operation is transmitted unchanged regardless
+   * of whether pathless PATCH normalization is enabled.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "value": {
+   *     "preferredLanguage": "de",
+   *     "active": true
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Pathless object is sent unchanged")
+  public void testPathlessObjectIsSentUnchanged(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+    attributes.put("active", true);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).valueNode(attributes).build();
+
+    JsonNode operation = sendAndGetOperation();
+
+    Assertions.assertFalse(operation.has("path"), operation.toPrettyString());
+
+    JsonNode value = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(value);
+    Assertions.assertTrue(value.isObject(), operation.toPrettyString());
+    Assertions.assertEquals("de", value.get("preferredLanguage").textValue());
+    Assertions.assertTrue(value.get("active").booleanValue());
+  }
+
+  /**
+   * Verifies that a singleton array containing a resource object remains untouched while the operation is being
+   * built and is unwrapped immediately before transmission when pathless PATCH normalization is enabled.
+   *
+   * <pre>{@code
+   * Built:
+   * {
+   *   "op": "replace",
+   *   "value": [{
+   *     "preferredLanguage": "de"
+   *   }]
+   * }
+   *
+   * Sent:
+   * {
+   *   "op": "replace",
+   *   "value": {
+   *     "preferredLanguage": "de"
+   *   }
+   * }
    * }</pre>
    */
   @Test
-  @DisplayName("Multiple values are serialized as an array")
-  public void testMultipleValuesAreSerializedAsArray()
+  @DisplayName("Pathless singleton object array is unwrapped when normalization is enabled")
+  public void testPathlessSingletonObjectArrayIsUnwrappedWhenNormalizationIsEnabled()
   {
-    PatchBuilder<User> patchBuilder = createPatchBuilder();
-    patchBuilder.addOperation().op(PatchOp.REPLACE).path("tags").values(Arrays.asList("tag-a", "tag-b")).build();
+    initialize(true);
 
-    JsonNode valueNode = getSerializedValue(patchBuilder.getResource());
-    Assertions.assertTrue(valueNode.isArray(), patchBuilder.getResource());
-    Assertions.assertEquals(2, valueNode.size());
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    ArrayNode values = JsonNodeFactory.instance.arrayNode();
+    values.add(attributes);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).valueNode(values).build();
+
+    // Building the PATCH operation must not implicitly alter the supplied value.
+    JsonNode builtValue = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(builtValue.isArray(), patchBuilder.getResource());
+    Assertions.assertEquals(1, builtValue.size());
+    Assertions.assertTrue(builtValue.get(0).isObject(), patchBuilder.getResource());
+
+    JsonNode sentOperation = sendAndGetOperation();
+    JsonNode sentValue = sentOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertFalse(sentOperation.has("path"), sentOperation.toPrettyString());
+    Assertions.assertNotNull(sentValue);
+    Assertions.assertTrue(sentValue.isObject(), sentOperation.toPrettyString());
+    Assertions.assertEquals("de", sentValue.get("preferredLanguage").textValue());
   }
 
+  /**
+   * Verifies that a singleton array containing a resource object is transmitted unchanged when pathless PATCH
+   * normalization is disabled.
+   *
+   * <pre>{@code
+   * Built and sent:
+   * {
+   *   "op": "replace",
+   *   "value": [{
+   *     "preferredLanguage": "de"
+   *   }]
+   * }
+   * }</pre>
+   */
+  @Test
+  @DisplayName("Pathless singleton object array remains unchanged when normalization is disabled")
+  public void testPathlessSingletonObjectArrayRemainsUnchangedWhenNormalizationIsDisabled()
+  {
+    initialize(false);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    ArrayNode values = JsonNodeFactory.instance.arrayNode();
+    values.add(attributes);
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).valueNode(values).build();
+
+    JsonNode builtValue = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(builtValue.isArray(), patchBuilder.getResource());
+    Assertions.assertEquals(1, builtValue.size());
+    Assertions.assertTrue(builtValue.get(0).isObject(), patchBuilder.getResource());
+
+    JsonNode sentOperation = sendAndGetOperation();
+    JsonNode sentValue = sentOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertFalse(sentOperation.has("path"), sentOperation.toPrettyString());
+    Assertions.assertNotNull(sentValue);
+    Assertions.assertTrue(sentValue.isArray(), sentOperation.toPrettyString());
+    Assertions.assertEquals(1, sentValue.size());
+    Assertions.assertTrue(sentValue.get(0).isObject(), sentOperation.toPrettyString());
+    Assertions.assertEquals("de", sentValue.get(0).get("preferredLanguage").textValue());
+  }
+
+  /**
+   * Verifies that a singleton object array created through the public {@code valueNodes} API is unwrapped
+   * before transmission when pathless PATCH normalization is enabled.
+   */
+  @Test
+  @DisplayName("Pathless singleton valueNodes object array is unwrapped when normalization is enabled")
+  public void testPathlessSingletonValueNodesObjectArrayIsUnwrappedWhenNormalizationIsEnabled()
+  {
+    initialize(true);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).valueNodes(Collections.singletonList(attributes)).build();
+
+    JsonNode builtValue = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(builtValue.isArray(), patchBuilder.getResource());
+
+    JsonNode sentValue = sendAndGetValue();
+
+    Assertions.assertTrue(sentValue.isObject(), sentValue.toPrettyString());
+    Assertions.assertEquals("de", sentValue.get("preferredLanguage").textValue());
+  }
+
+  /**
+   * Verifies that a singleton object array created through the public {@code valueNodes} API remains unchanged
+   * during transmission when pathless PATCH normalization is disabled.
+   */
+  @Test
+  @DisplayName("Pathless singleton valueNodes object array remains unchanged when normalization is disabled")
+  public void testPathlessSingletonValueNodesObjectArrayRemainsUnchangedWhenNormalizationIsDisabled()
+  {
+    initialize(false);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    patchBuilder.addOperation().op(PatchOp.REPLACE).valueNodes(Collections.singletonList(attributes)).build();
+
+    JsonNode builtValue = getSerializedValue(patchBuilder.getResource());
+    Assertions.assertTrue(builtValue.isArray(), patchBuilder.getResource());
+
+    JsonNode sentValue = sendAndGetValue();
+
+    Assertions.assertTrue(sentValue.isArray(), sentValue.toPrettyString());
+    Assertions.assertEquals(1, sentValue.size());
+    Assertions.assertTrue(sentValue.get(0).isObject(), sentValue.toPrettyString());
+    Assertions.assertEquals("de", sentValue.get(0).get("preferredLanguage").textValue());
+  }
+
+  /**
+   * Verifies that the final state of an operation determines its wire representation.
+   * <p>
+   * If an operation receives a path after it was initially built without one, an explicitly supplied singleton
+   * array must remain an array during transmission regardless of whether pathless PATCH normalization is
+   * enabled.
+   * </p>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Singleton array remains unchanged when path is assigned after build")
+  public void testSingletonArrayRemainsUnchangedWhenPathIsAssignedAfterBuild(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    ArrayNode roles = JsonNodeFactory.instance.arrayNode();
+    roles.add("ADMIN");
+
+    PatchRequestOperation operation = PatchRequestOperation.builder().op(PatchOp.ADD).valueNode(roles).build();
+    operation.setPath("roles");
+
+    patchBuilder.setPatchResource(PatchOpRequest.builder().operations(Collections.singletonList(operation)).build());
+
+    JsonNode sentOperation = sendAndGetOperation();
+    JsonNode sentValue = sentOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertEquals("roles", sentOperation.get("path").textValue());
+    Assertions.assertNotNull(sentValue);
+    Assertions.assertTrue(sentValue.isArray(), sentOperation.toPrettyString());
+    Assertions.assertEquals(1, sentValue.size());
+    Assertions.assertEquals("ADMIN", sentValue.get(0).textValue());
+  }
+
+  /**
+   * Verifies that normalization is applied individually according to the final path of each operation when
+   * pathless PATCH normalization is enabled.
+   */
+  @Test
+  @DisplayName("Each PATCH operation is normalized according to its final path when normalization is enabled")
+  public void testEachPatchOperationIsNormalizedAccordingToItsFinalPathWhenNormalizationIsEnabled()
+  {
+    initialize(true);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    ArrayNode resourceValues = JsonNodeFactory.instance.arrayNode();
+    resourceValues.add(attributes);
+
+    ArrayNode roles = JsonNodeFactory.instance.arrayNode();
+    roles.add("ADMIN");
+
+    patchBuilder.addOperation()
+                .op(PatchOp.REPLACE)
+                .valueNode(resourceValues)
+                .next()
+                .op(PatchOp.ADD)
+                .path("roles")
+                .valueNode(roles)
+                .build();
+
+    JsonNode patchRequest = sendAndGetPatchRequest();
+    JsonNode operations = patchRequest.get(AttributeNames.RFC7643.OPERATIONS);
+
+    Assertions.assertNotNull(operations);
+    Assertions.assertTrue(operations.isArray(), patchRequest.toPrettyString());
+    Assertions.assertEquals(2, operations.size());
+
+    JsonNode pathlessOperation = operations.get(0);
+    JsonNode pathlessValue = pathlessOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertFalse(pathlessOperation.has("path"), pathlessOperation.toPrettyString());
+    Assertions.assertTrue(pathlessValue.isObject(), pathlessOperation.toPrettyString());
+    Assertions.assertEquals("de", pathlessValue.get("preferredLanguage").textValue());
+
+    JsonNode pathBasedOperation = operations.get(1);
+    JsonNode pathBasedValue = pathBasedOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertEquals("roles", pathBasedOperation.get("path").textValue());
+    Assertions.assertTrue(pathBasedValue.isArray(), pathBasedOperation.toPrettyString());
+    Assertions.assertEquals(1, pathBasedValue.size());
+    Assertions.assertEquals("ADMIN", pathBasedValue.get(0).textValue());
+  }
+
+  /**
+   * Verifies that operations retain their supplied representation during transmission when pathless PATCH
+   * normalization is disabled.
+   */
+  @Test
+  @DisplayName("PATCH operations remain unchanged when normalization is disabled")
+  public void testPatchOperationsRemainUnchangedWhenNormalizationIsDisabled()
+  {
+    initialize(false);
+
+    ObjectNode attributes = JsonNodeFactory.instance.objectNode();
+    attributes.put("preferredLanguage", "de");
+
+    ArrayNode resourceValues = JsonNodeFactory.instance.arrayNode();
+    resourceValues.add(attributes);
+
+    ArrayNode roles = JsonNodeFactory.instance.arrayNode();
+    roles.add("ADMIN");
+
+    patchBuilder.addOperation()
+                .op(PatchOp.REPLACE)
+                .valueNode(resourceValues)
+                .next()
+                .op(PatchOp.ADD)
+                .path("roles")
+                .valueNode(roles)
+                .build();
+
+    JsonNode patchRequest = sendAndGetPatchRequest();
+    JsonNode operations = patchRequest.get(AttributeNames.RFC7643.OPERATIONS);
+
+    Assertions.assertNotNull(operations);
+    Assertions.assertTrue(operations.isArray(), patchRequest.toPrettyString());
+    Assertions.assertEquals(2, operations.size());
+
+    JsonNode pathlessOperation = operations.get(0);
+    JsonNode pathlessValue = pathlessOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertFalse(pathlessOperation.has("path"), pathlessOperation.toPrettyString());
+    Assertions.assertTrue(pathlessValue.isArray(), pathlessOperation.toPrettyString());
+    Assertions.assertEquals(1, pathlessValue.size());
+    Assertions.assertTrue(pathlessValue.get(0).isObject(), pathlessOperation.toPrettyString());
+    Assertions.assertEquals("de", pathlessValue.get(0).get("preferredLanguage").textValue());
+
+    JsonNode pathBasedOperation = operations.get(1);
+    JsonNode pathBasedValue = pathBasedOperation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertEquals("roles", pathBasedOperation.get("path").textValue());
+    Assertions.assertTrue(pathBasedValue.isArray(), pathBasedOperation.toPrettyString());
+    Assertions.assertEquals(1, pathBasedValue.size());
+    Assertions.assertEquals("ADMIN", pathBasedValue.get(0).textValue());
+  }
+
+  /**
+   * Verifies that a remove operation with a path is transmitted without an artificial value attribute
+   * regardless of whether pathless PATCH normalization is enabled.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "remove",
+   *   "path": "nickName"
+   * }
+   * }</pre>
+   *
+   * @param normalizePathlessPatchOperations whether pathless PATCH normalization is enabled
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  @DisplayName("Path-based remove operation is sent without value")
+  public void testPathBasedRemoveOperationIsSentWithoutValue(boolean normalizePathlessPatchOperations)
+  {
+    initialize(normalizePathlessPatchOperations);
+
+    patchBuilder.addOperation().op(PatchOp.REMOVE).path("nickName").build();
+
+    JsonNode operation = sendAndGetOperation();
+
+    Assertions.assertEquals("remove", operation.get("op").textValue());
+    Assertions.assertEquals("nickName", operation.get("path").textValue());
+    Assertions.assertFalse(operation.has(AttributeNames.RFC7643.VALUE), operation.toPrettyString());
+  }
+
+  /**
+   * Sends the PATCH request through the regular public {@link PatchBuilder#sendRequest()} API and returns the
+   * first serialized operation that would have been sent to the remote SCIM provider.
+   */
+  private JsonNode sendAndGetOperation()
+  {
+    JsonNode patchRequest = sendAndGetPatchRequest();
+    JsonNode operations = patchRequest.get(AttributeNames.RFC7643.OPERATIONS);
+
+    Assertions.assertNotNull(operations, patchRequest.toPrettyString());
+    Assertions.assertTrue(operations.isArray(), patchRequest.toPrettyString());
+    Assertions.assertFalse(operations.isEmpty(), patchRequest.toPrettyString());
+
+    return operations.get(0);
+  }
+
+  /**
+   * Sends the PATCH request and returns the value of its first operation.
+   */
+  private JsonNode sendAndGetValue()
+  {
+    JsonNode operation = sendAndGetOperation();
+    JsonNode value = operation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertNotNull(value, operation.toPrettyString());
+    return value;
+  }
+
+  /**
+   * Sends the PATCH request and returns the complete JSON document that was passed to the HTTP client.
+   */
+  private JsonNode sendAndGetPatchRequest()
+  {
+    HttpUriRequest request = sendAndGetRequest();
+    return JsonHelper.readJsonDocument(getRequestBody(request));
+  }
+
+  /**
+   * Sends the request through the regular public API and captures the actual HTTP request immediately before it
+   * would have been sent to the remote SCIM provider.
+   */
+  private HttpUriRequest sendAndGetRequest()
+  {
+    patchBuilder.sendRequest();
+
+    ArgumentCaptor<HttpUriRequest> requestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+    Mockito.verify(scimHttpClient, Mockito.times(1)).sendRequest(requestCaptor.capture());
+
+    return requestCaptor.getValue();
+  }
+
+  /**
+   * Extracts the serialized PATCH body from the captured HTTP request.
+   */
+  private String getRequestBody(HttpUriRequest request)
+  {
+    Assertions.assertTrue(request instanceof HttpPatch, "Expected HttpPatch but got: " + request.getClass());
+
+    HttpPatch httpPatch = (HttpPatch)request;
+    Assertions.assertNotNull(httpPatch.getEntity());
+
+    try
+    {
+      return EntityUtils.toString(httpPatch.getEntity(), StandardCharsets.UTF_8);
+    }
+    catch (IOException ex)
+    {
+      throw new IllegalStateException("Could not read PATCH request body", ex);
+    }
+  }
+
+  /**
+   * Returns the value of the first operation from an already serialized PATCH resource.
+   */
   private JsonNode getSerializedValue(String patchRequestResource)
   {
     JsonNode patchRequest = JsonHelper.readJsonDocument(patchRequestResource);
-    return patchRequest.get("Operations").get(0).get("value");
+    return patchRequest.get(AttributeNames.RFC7643.OPERATIONS).get(0).get(AttributeNames.RFC7643.VALUE);
   }
 }

--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
@@ -1,7 +1,6 @@
 package de.captaingoldfish.scim.sdk.common.request;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -117,19 +116,13 @@ public class PatchRequestOperation extends ScimObjectNode
   }
 
   /**
-   * the new value of the targeted attribute
+   * the new value of the targeted attribute. A single value is stored as a scalar regardless of whether a path
+   * is present, so the serialized operation is RFC 7644 compliant for single-valued attributes. See issue #968.
    */
   public void setValue(String value)
   {
     valueExtracted = false;
-    if (getPath().isPresent())
-    {
-      setAttributeList(AttributeNames.RFC7643.VALUE, value == null ? null : Collections.singletonList(value));
-    }
-    else
-    {
-      setAttribute(AttributeNames.RFC7643.VALUE, value);
-    }
+    setAttribute(AttributeNames.RFC7643.VALUE, value);
   }
 
   /**
@@ -151,7 +144,8 @@ public class PatchRequestOperation extends ScimObjectNode
   }
 
   /**
-   * the new value of the targeted attribute
+   * the new value of the targeted attribute. A single value is stored as a scalar regardless of whether a path
+   * is present, so the serialized operation is RFC 7644 compliant for single-valued attributes. See issue #968.
    */
   public void setValues(List<String> value)
   {
@@ -166,14 +160,7 @@ public class PatchRequestOperation extends ScimObjectNode
     }
     else
     {
-      if (getPath().isPresent())
-      {
-        setAttributeList(AttributeNames.RFC7643.VALUE, value);
-      }
-      else
-      {
-        setAttribute(AttributeNames.RFC7643.VALUE, value.get(0));
-      }
+      setAttribute(AttributeNames.RFC7643.VALUE, value.get(0));
     }
   }
 

--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -66,10 +64,6 @@ public class PatchRequestOperation extends ScimObjectNode
   public void setPath(String path)
   {
     setAttribute(AttributeNames.RFC7643.PATH, path);
-    if (StringUtils.isBlank(path))
-    {
-      unwrapSingletonArrayValue();
-    }
   }
 
   /**
@@ -106,11 +100,6 @@ public class PatchRequestOperation extends ScimObjectNode
       return Optional.of(valueNode);
     }
     valueNode = materializeStructuredValue(valueNode);
-    if (valueNode.isObject() || valueNode.isArray())
-    {
-      valueExtracted = true;
-      return Optional.of(valueNode);
-    }
     valueExtracted = true;
     return Optional.ofNullable(valueNode);
   }
@@ -247,27 +236,7 @@ public class PatchRequestOperation extends ScimObjectNode
       return;
     }
     valueExtracted = false;
-    if (!getPath().isPresent() && value.isArray() && value.size() == 1)
-    {
-      set(AttributeNames.RFC7643.VALUE, value.get(0));
-    }
-    else
-    {
-      set(AttributeNames.RFC7643.VALUE, value);
-    }
-  }
-
-  /**
-   * A pathless add or replace operation addresses a set of resource attributes and therefore requires an object
-   * value. This retains the historic normalization for callers that supply this object in a singleton array.
-   */
-  private void unwrapSingletonArrayValue()
-  {
-    JsonNode value = get(AttributeNames.RFC7643.VALUE);
-    if (value != null && value.isArray() && value.size() == 1)
-    {
-      set(AttributeNames.RFC7643.VALUE, value.get(0));
-    }
+    set(AttributeNames.RFC7643.VALUE, value);
   }
 
   public static class PatchRequestOperationBuilder

--- a/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
+++ b/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 
 import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
 import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
-import de.captaingoldfish.scim.sdk.common.resources.Group;
 import de.captaingoldfish.scim.sdk.common.resources.User;
 import de.captaingoldfish.scim.sdk.common.resources.complex.Name;
 import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
@@ -291,7 +290,7 @@ public class PatchRequestOperationTest
    * After getter:  {"op":"replace","path":"manager","value":{"value":"bulkId:2"}}
    * After modify:  {"op":"replace","path":"manager","value":{"value":"resolved-id"}}
    * }</pre>
-   * 
+   *
    * This mutable-node contract is used by the bulkId resolver to replace references in place.
    */
   @Test
@@ -352,48 +351,105 @@ public class PatchRequestOperationTest
   }
 
   /**
-   * Verifies the RFC 7644 pathless-replace normalization used by resource reconciliation. A resource supplied
-   * in a singleton array is serialized as the required set-of-attributes object.
+   * Verifies that an explicitly supplied singleton {@link ArrayNode} is preserved when the path is provided
+   * directly through the builder.
+   * <p>
+   * A singleton array may represent a multi-valued SCIM attribute containing exactly one value and must
+   * therefore not be unwrapped into a scalar value.
+   * </p>
    *
    * <pre>{@code
-   * Input valueNode:
-   * [{
-   *   "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-   *   "externalId": "external-id",
-   *   "displayName": "example/developers"
-   * }]
+   * Input:
+   * path="roles", valueNode=["ADMIN"]
    *
-   * Serialized operation:
+   * Expected:
    * {
-   *   "op": "replace",
-   *   "value": {
-   *     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-   *     "externalId": "external-id",
-   *     "displayName": "example/developers"
-   *   }
+   *   "op": "add",
+   *   "path": "roles",
+   *   "value": ["ADMIN"]
    * }
    * }</pre>
    *
-   * The output must contain neither {@code "value":[{...}]} nor an escaped JSON string.
+   * This is especially important for multi-valued attributes because the number of supplied values does not
+   * determine whether the targeted SCIM attribute itself is single- or multi-valued.
    *
-   * @see <a href="https://github.com/Captain-P-Goldfish/scim-for-keycloak/issues/172">scim-for-keycloak issue
-   *      #172</a>
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
    */
   @Test
-  @DisplayName("Pathless replace serializes a singleton resource array as an object")
-  public void testPathlessReplaceWithSingletonResourceArray()
+  @DisplayName("Preserves singleton array when path is provided through builder")
+  public void testPreservesSingletonArrayWhenPathIsProvidedThroughBuilder()
   {
-    Group group = Group.builder().externalId("external-id").displayName("example/developers").build();
-    ArrayNode groupArray = new ArrayNode(JsonNodeFactory.instance);
-    groupArray.add(group);
+    ArrayNode roles = new ArrayNode(JsonNodeFactory.instance);
+    roles.add("ADMIN");
 
-    PatchRequestOperation operation = PatchRequestOperation.builder().op(PatchOp.REPLACE).valueNode(groupArray).build();
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.ADD)
+                                                           .path("roles")
+                                                           .valueNode(roles)
+                                                           .build();
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(internalValue);
+    Assertions.assertTrue(internalValue.isArray(), operation.toPrettyString());
+    Assertions.assertEquals(1, internalValue.size());
+    Assertions.assertEquals("ADMIN", internalValue.get(0).textValue());
 
     JsonNode serializedOperation = JsonHelper.readJsonDocument(operation.toString());
-    Assertions.assertFalse(serializedOperation.has(AttributeNames.RFC7643.PATH));
-    Assertions.assertTrue(serializedOperation.get(AttributeNames.RFC7643.VALUE).isObject(), operation.toString());
-    Assertions.assertEquals("example/developers",
-                            serializedOperation.get(AttributeNames.RFC7643.VALUE).get("displayName").textValue());
+    JsonNode serializedValue = serializedOperation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(serializedValue.isArray(), operation.toPrettyString());
+    Assertions.assertEquals(1, serializedValue.size());
+    Assertions.assertEquals("ADMIN", serializedValue.get(0).textValue());
   }
 
+  /**
+   * Verifies that an explicitly supplied singleton {@link ArrayNode} remains unchanged when the path is
+   * assigned after the operation has already been built.
+   * <p>
+   * The JSON representation of the value must not depend on the order in which the value and path are assigned.
+   * An explicitly supplied array must therefore remain an array even if the operation was initially created
+   * without a path.
+   * </p>
+   *
+   * <pre>{@code
+   * Initial operation:
+   * valueNode=["ADMIN"]
+   *
+   * Afterwards:
+   * path="roles"
+   *
+   * Expected:
+   * {
+   *   "op": "add",
+   *   "path": "roles",
+   *   "value": ["ADMIN"]
+   * }
+   * }</pre>
+   *
+   * This ensures that constructing a {@link PatchRequestOperation} in multiple steps does not implicitly change
+   * the JSON type of its value.
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("Preserves singleton array when path is assigned after build")
+  public void testPreservesSingletonArrayWhenPathIsAssignedAfterBuild()
+  {
+    ArrayNode roles = new ArrayNode(JsonNodeFactory.instance);
+    roles.add("ADMIN");
+
+    PatchRequestOperation operation = PatchRequestOperation.builder().op(PatchOp.ADD).valueNode(roles).build();
+    operation.setPath("roles");
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(internalValue);
+    Assertions.assertTrue(internalValue.isArray(), operation.toPrettyString());
+    Assertions.assertEquals(1, internalValue.size());
+    Assertions.assertEquals("ADMIN", internalValue.get(0).textValue());
+
+    JsonNode serializedOperation = JsonHelper.readJsonDocument(operation.toString());
+    JsonNode serializedValue = serializedOperation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(serializedValue.isArray(), operation.toPrettyString());
+    Assertions.assertEquals(1, serializedValue.size());
+    Assertions.assertEquals("ADMIN", serializedValue.get(0).textValue());
+  }
 }

--- a/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
+++ b/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
@@ -166,6 +166,91 @@ public class PatchRequestOperationTest
   }
 
   /**
+   * Verifies that setting a single value through {@code setValue(String)} after the path has been set stores a
+   * scalar instead of a singleton array, keeping the serialized operation RFC 7644 compliant for single-valued
+   * attributes.
+   *
+   * <pre>{@code
+   * {"op":"replace","path":"preferredLanguage","value":"de"}
+   * }</pre>
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("setValue after setPath stores a scalar")
+  public void testSetValueAfterSetPathStoresScalar()
+  {
+    PatchRequestOperation operation = new PatchRequestOperation();
+    operation.setOp(PatchOp.REPLACE);
+    operation.setPath("preferredLanguage");
+    operation.setValue("de");
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(internalValue.isTextual(), operation.toPrettyString());
+    Assertions.assertEquals("de", internalValue.textValue());
+
+    JsonNode serializedOperation = JsonHelper.readJsonDocument(operation.toString());
+    Assertions.assertEquals("de", serializedOperation.get(AttributeNames.RFC7643.VALUE).textValue());
+  }
+
+  /**
+   * Verifies that setting a singleton list through {@code setValues(List)} after the path has been set stores a
+   * scalar instead of a singleton array, while multiple values remain an array.
+   *
+   * <pre>{@code
+   * {"op":"replace","path":"preferredLanguage","value":"de"}
+   * {"op":"replace","path":"tags","value":["tag-a","tag-b"]}
+   * }</pre>
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("setValues after setPath stores scalar for single value and array for multiple")
+  public void testSetValuesAfterSetPath()
+  {
+    PatchRequestOperation singleValueOperation = new PatchRequestOperation();
+    singleValueOperation.setOp(PatchOp.REPLACE);
+    singleValueOperation.setPath("preferredLanguage");
+    singleValueOperation.setValues(Arrays.asList("de"));
+
+    JsonNode singleValue = singleValueOperation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(singleValue.isTextual(), singleValueOperation.toPrettyString());
+    Assertions.assertEquals("de", singleValue.textValue());
+
+    PatchRequestOperation multiValueOperation = new PatchRequestOperation();
+    multiValueOperation.setOp(PatchOp.REPLACE);
+    multiValueOperation.setPath("tags");
+    multiValueOperation.setValues(Arrays.asList("tag-a", "tag-b"));
+
+    JsonNode multiValue = multiValueOperation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(multiValue.isArray(), multiValueOperation.toPrettyString());
+    Assertions.assertEquals(2, multiValue.size());
+  }
+
+  /**
+   * Verifies that a single scalar stored through {@code setValue(String)} with a path retains its string type
+   * after the value has been read through {@link PatchRequestOperation#getValueNode()}, so values such as
+   * {@code "67890"} are not converted into numbers.
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("getValueNode does not convert numeric strings into numbers")
+  public void testNumericStringValueIsNotParsed()
+  {
+    PatchRequestOperation operation = new PatchRequestOperation();
+    operation.setOp(PatchOp.REPLACE);
+    operation.setPath("preferredLanguage");
+    operation.setValue("67890");
+
+    operation.getValueNode();
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertTrue(internalValue.isTextual(), operation.toPrettyString());
+    Assertions.assertEquals("67890", internalValue.textValue());
+  }
+
+  /**
    * Verifies the distinction between the stored wire value and the normalized server-processing view returned
    * by {@link PatchRequestOperation#getValueNode()}.
    *

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/bulkid/BulkIdResolverTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/endpoints/bulkid/BulkIdResolverTest.java
@@ -437,8 +437,10 @@ public class BulkIdResolverTest
 
     final String valueNode1 = String.format("{\"%s\": \"%s\"}", AttributeNames.RFC7643.VALUE, toReference(bulkId2));
     final String valueNode2 = String.format("{\"%s\": \"%s\"}", AttributeNames.RFC7643.VALUE, toReference(bulkId3));
-    final String expectedValueNode1 = String.format("{\"%s\":\"%s\"}", AttributeNames.RFC7643.VALUE, userId1);
-    final String expectedValueNode2 = String.format("{\"%s\":\"%s\"}", AttributeNames.RFC7643.VALUE, userId2);
+    // single values are stored as scalars since #968, so the resolved value keeps its raw string form and is
+    // materialized lazily when the value-node is accessed
+    final String expectedValueNode1 = valueNode1.replace(toReference(bulkId2), userId1);
+    final String expectedValueNode2 = valueNode2.replace(toReference(bulkId3), userId2);
 
     List<PatchRequestOperation> operations = Arrays.asList(PatchRequestOperation.builder()
                                                                                 .path(AttributeNames.RFC7643.MANAGER)

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/PatchFilteredSubAttributeReplaceRegressionTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/PatchFilteredSubAttributeReplaceRegressionTest.java
@@ -1,0 +1,166 @@
+package de.captaingoldfish.scim.sdk.server.patch;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
+import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
+import de.captaingoldfish.scim.sdk.common.request.PatchOpRequest;
+import de.captaingoldfish.scim.sdk.common.request.PatchRequestOperation;
+import de.captaingoldfish.scim.sdk.common.resources.ServiceProvider;
+import de.captaingoldfish.scim.sdk.common.resources.User;
+import de.captaingoldfish.scim.sdk.common.resources.complex.PatchConfig;
+import de.captaingoldfish.scim.sdk.common.resources.multicomplex.Address;
+import de.captaingoldfish.scim.sdk.server.endpoints.Context;
+import de.captaingoldfish.scim.sdk.server.endpoints.ResourceEndpoint;
+import de.captaingoldfish.scim.sdk.server.endpoints.base.UserEndpointDefinition;
+import de.captaingoldfish.scim.sdk.server.endpoints.handler.UserHandlerImpl;
+
+
+/**
+ * Regression tests for PATCH replace operations targeting a sub-attribute of a multi-valued complex attribute
+ * through a value filter.
+ * <p>
+ * Scalar PATCH values containing whitespace must retain their complete value while the
+ * {@link PatchRequestOperation} is built and when the operation is subsequently applied to the resource.
+ * </p>
+ */
+public class PatchFilteredSubAttributeReplaceRegressionTest
+{
+
+  private ResourceEndpoint resourceEndpoint;
+
+  /**
+   * Initializes a resource endpoint with PATCH support.
+   */
+  @BeforeEach
+  public void initialize()
+  {
+    ServiceProvider serviceProvider = ServiceProvider.builder()
+                                                     .patchConfig(PatchConfig.builder().supported(true).build())
+                                                     .build();
+    resourceEndpoint = new ResourceEndpoint(serviceProvider);
+  }
+
+  /**
+   * Verifies that building a path-based PATCH operation does not modify a multi-word scalar value.
+   * <p>
+   * This specifically covers the construction path used by {@link PatchRequestOperation#builder()}. The
+   * presence of a path must not cause the textual value to be parsed, wrapped or otherwise modified.
+   * </p>
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "addresses[type eq \"work\"].streetAddress",
+   *   "value": "7070 Phoebe Hollow"
+   * }
+   * }</pre>
+   */
+  @Test
+  @DisplayName("Path-based multi-word scalar remains unchanged while operation is built")
+  public void testPathBasedMultiWordScalarRemainsUnchangedWhileOperationIsBuilt()
+  {
+    final String newStreetAddress = "7070 Phoebe Hollow";
+
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.REPLACE)
+                                                           .path("addresses[type eq \"work\"].streetAddress")
+                                                           .valueNode(TextNode.valueOf(newStreetAddress))
+                                                           .build();
+
+    JsonNode value = operation.get(AttributeNames.RFC7643.VALUE);
+
+    Assertions.assertNotNull(value, operation.toPrettyString());
+    Assertions.assertTrue(value.isTextual(), operation.toPrettyString());
+    Assertions.assertEquals(newStreetAddress, value.textValue(), operation.toPrettyString());
+  }
+
+  /**
+   * Verifies that replacing a simple sub-attribute of a filtered multi-valued complex attribute preserves the
+   * complete textual value, including all whitespace.
+   *
+   * <pre>{@code
+   * {
+   *   "op": "replace",
+   *   "path": "addresses[type eq \"work\"].streetAddress",
+   *   "value": "7070 Phoebe Hollow"
+   * }
+   * }</pre>
+   * <p>
+   * Only the address selected by the filter must be modified. Other attributes of the selected address and all
+   * non-matching addresses must remain unchanged.
+   * </p>
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/972">
+   *      https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/972</a>
+   */
+  @Test
+  @DisplayName("Filtered replace preserves complete multi-word sub-attribute value")
+  public void testFilteredReplacePreservesCompleteMultiWordSubAttributeValue()
+  {
+    final String resourceId = "12345289-86cf-21c5-a6dd-de6daebd4eae";
+    final String newStreetAddress = "7070 Phoebe Hollow";
+
+    UserHandlerImpl userHandler = new UserHandlerImpl(false);
+    resourceEndpoint.registerEndpoint(new UserEndpointDefinition(userHandler));
+
+    Address workAddress = Address.builder().type("work").streetAddress("910 Broadway").locality("New York").build();
+
+    Address homeAddress = Address.builder().type("home").streetAddress("1 Home Lane").build();
+
+    User user = User.builder()
+                    .id(resourceId)
+                    .userName("John Smith")
+                    .addresses(Arrays.asList(workAddress, homeAddress))
+                    .build();
+
+    userHandler.getInMemoryMap().put(resourceId, user);
+
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.REPLACE)
+                                                           .path("addresses[type eq \"work\"].streetAddress")
+                                                           .valueNode(TextNode.valueOf(newStreetAddress))
+                                                           .build();
+
+    PatchOpRequest patchOpRequest = PatchOpRequest.builder().operations(Collections.singletonList(operation)).build();
+
+    PatchRequestHandler<User> patchRequestHandler = new PatchRequestHandler<>(resourceId, userHandler,
+                                                                              resourceEndpoint.getPatchWorkarounds(),
+                                                                              new Context(null));
+
+    User patchedUser = patchRequestHandler.handlePatchRequest(patchOpRequest);
+
+    Assertions.assertTrue(patchRequestHandler.isResourceChanged(), patchedUser.toPrettyString());
+    Assertions.assertEquals(2, patchedUser.getAddresses().size(), patchedUser.toPrettyString());
+
+    Address patchedWorkAddress = patchedUser.getAddresses()
+                                            .stream()
+                                            .filter(address -> "work".equals(address.getType().orElse(null)))
+                                            .findFirst()
+                                            .orElseThrow(AssertionError::new);
+
+    Assertions.assertEquals(newStreetAddress,
+                            patchedWorkAddress.getStreetAddress().orElse(null),
+                            patchedUser.toPrettyString());
+    Assertions.assertEquals("New York", patchedWorkAddress.getLocality().orElse(null), patchedUser.toPrettyString());
+
+    Address patchedHomeAddress = patchedUser.getAddresses()
+                                            .stream()
+                                            .filter(address -> "home".equals(address.getType().orElse(null)))
+                                            .findFirst()
+                                            .orElseThrow(AssertionError::new);
+
+    Assertions.assertEquals("1 Home Lane",
+                            patchedHomeAddress.getStreetAddress().orElse(null),
+                            patchedUser.toPrettyString());
+  }
+}


### PR DESCRIPTION
## Summary

Completes the fix for #968: `setValue(String)` and `setValues(List)` still wrapped single values in a singleton array when the path was set before the value (direct API usage), producing `"value": ["de"]` instead of the RFC 7644 compliant `"value": "de"`.

The builder flows were already fixed in `f618908a` because the Lombok constructor sets the value before the path, but the direct setters remained order-dependent.

## Changes

- `PatchRequestOperation.setValue(String)` — stores a scalar regardless of path presence.
- `PatchRequestOperation.setValues(List)` — stores a scalar for a single value regardless of path presence; multiple values remain an array (unchanged).
- JSON-encoded object strings are no longer eagerly parsed on set; they are materialized lazily through `getValueNode()`/`getValue()` (same semantics as `setValueNode(TextNode)`).
- Updated `BulkIdResolverTest.testComplexPatchPathWithComplexTypeReference` to expect the raw replaced string, since single values are now stored as scalars.
- Added regression tests:
  - `PatchRequestOperationTest` — `setValue`/`setValues` after `setPath` store scalars; multiple values stay an array; numeric strings like `"67890"` keep their string type.
  - `PatchBuilderWireFormatTest` (new) — wire format of the client `PatchBuilder` for the exact repros from #968: scalar `valueNode`, numeric strings, and multi-value arrays.

## Test plan

- `mvn test` — full suite green (2410+ tests across all modules)
- `mvn formatter:validate` — clean

Note: I used Claude Code to help locate the root cause and draft the fix. I reviewed the change, ran the full test suite locally, and take responsibility for it.