### PR TITLE
 Preserve caller-supplied value type in PATCH operations

### DIFF
--- a/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
+++ b/scim-sdk-client/src/main/java/de/captaingoldfish/scim/sdk/client/builder/PatchBuilder.java
@@ -14,6 +14,7 @@ import org.apache.http.entity.StringEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import de.captaingoldfish.scim.sdk.client.ScimClientConfig;
 import de.captaingoldfish.scim.sdk.client.http.HttpResponse;
@@ -301,7 +302,7 @@ public class PatchBuilder<T extends ResourceNode> extends ETagRequestBuilder<T>
      */
     public PatchOperationBuilder<T> value(String values)
     {
-      builder.values(Collections.singletonList(values));
+      builder.valueNode(values == null ? null : TextNode.valueOf(values));
       return this;
     }
 

--- a/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
+++ b/scim-sdk-common/src/main/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperation.java
@@ -1,11 +1,7 @@
 package de.captaingoldfish.scim.sdk.common.request;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -67,10 +63,6 @@ public class PatchRequestOperation extends ScimObjectNode
   public void setPath(String path)
   {
     setAttribute(AttributeNames.RFC7643.PATH, path);
-    if (StringUtils.isBlank(path))
-    {
-      unwrapSingletonArrayValue();
-    }
   }
 
   /**
@@ -117,19 +109,13 @@ public class PatchRequestOperation extends ScimObjectNode
   }
 
   /**
-   * the new value of the targeted attribute
+   * sets a single scalar value for the targeted attribute. The value is stored verbatim as a scalar string.
+   * {@link #getValues()} and {@link #getValueNode()} present it as a single-element array during processing.
    */
   public void setValue(String value)
   {
     valueExtracted = false;
-    if (getPath().isPresent())
-    {
-      setAttributeList(AttributeNames.RFC7643.VALUE, value == null ? null : Collections.singletonList(value));
-    }
-    else
-    {
-      setAttribute(AttributeNames.RFC7643.VALUE, value);
-    }
+    setAttribute(AttributeNames.RFC7643.VALUE, value);
   }
 
   /**
@@ -151,7 +137,9 @@ public class PatchRequestOperation extends ScimObjectNode
   }
 
   /**
-   * the new value of the targeted attribute
+   * sets the values for the targeted attribute. The values are stored as a JSON array, so a singleton list
+   * serializes as {@code "value":["..."]} rather than a scalar. For a single scalar value use
+   * {@link #setValue(String)} instead.
    */
   public void setValues(List<String> value)
   {
@@ -160,20 +148,9 @@ public class PatchRequestOperation extends ScimObjectNode
     {
       remove(AttributeNames.RFC7643.VALUE);
     }
-    else if (value.size() > 1)
-    {
-      setAttributeList(AttributeNames.RFC7643.VALUE, value);
-    }
     else
     {
-      if (getPath().isPresent())
-      {
-        setAttributeList(AttributeNames.RFC7643.VALUE, value);
-      }
-      else
-      {
-        setAttribute(AttributeNames.RFC7643.VALUE, value.get(0));
-      }
+      setAttributeList(AttributeNames.RFC7643.VALUE, value);
     }
   }
 
@@ -250,7 +227,9 @@ public class PatchRequestOperation extends ScimObjectNode
   }
 
   /**
-   * the new value of the targeted attribute. in this case the value is represented by the resource itself
+   * sets the value of the targeted attribute as a JSON node. The node is stored verbatim, preserving its type
+   * (scalar, object, or array). This is the appropriate setter for multivalued attributes, whose values are
+   * represented as arrays (e.g. {@code ["ADMIN"]} or {@code [{...}]}).
    */
   public void setValueNode(JsonNode value)
   {
@@ -260,27 +239,7 @@ public class PatchRequestOperation extends ScimObjectNode
       return;
     }
     valueExtracted = false;
-    if (!getPath().isPresent() && value.isArray() && value.size() == 1)
-    {
-      set(AttributeNames.RFC7643.VALUE, value.get(0));
-    }
-    else
-    {
-      set(AttributeNames.RFC7643.VALUE, value);
-    }
-  }
-
-  /**
-   * A pathless add or replace operation addresses a set of resource attributes and therefore requires an object
-   * value. This retains the historic normalization for callers that supply this object in a singleton array.
-   */
-  private void unwrapSingletonArrayValue()
-  {
-    JsonNode value = get(AttributeNames.RFC7643.VALUE);
-    if (value != null && value.isArray() && value.size() == 1)
-    {
-      set(AttributeNames.RFC7643.VALUE, value.get(0));
-    }
+    set(AttributeNames.RFC7643.VALUE, value);
   }
 
   public static class PatchRequestOperationBuilder
@@ -289,9 +248,14 @@ public class PatchRequestOperation extends ScimObjectNode
     public PatchRequestOperationBuilder()
     {}
 
+    /**
+     * sets a single scalar value for the operation. The value is stored as a scalar string, so it serializes as
+     * {@code "value":"..."}. For an explicit array value use {@link #values(List)} or
+     * {@link #valueNode(JsonNode)}.
+     */
     public PatchRequestOperationBuilder value(String value)
     {
-      this.values(Arrays.asList(value));
+      this.valueNode(value == null ? null : TextNode.valueOf(value));
       return this;
     }
   }

--- a/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
+++ b/scim-sdk-common/src/test/java/de/captaingoldfish/scim/sdk/common/request/PatchRequestOperationTest.java
@@ -1,6 +1,7 @@
 package de.captaingoldfish.scim.sdk.common.request;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,7 +19,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 
 import de.captaingoldfish.scim.sdk.common.constants.AttributeNames;
 import de.captaingoldfish.scim.sdk.common.constants.enums.PatchOp;
-import de.captaingoldfish.scim.sdk.common.resources.Group;
 import de.captaingoldfish.scim.sdk.common.resources.User;
 import de.captaingoldfish.scim.sdk.common.resources.complex.Name;
 import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
@@ -267,48 +267,178 @@ public class PatchRequestOperationTest
   }
 
   /**
-   * Verifies the RFC 7644 pathless-replace normalization used by resource reconciliation. A resource supplied
-   * in a singleton array is serialized as the required set-of-attributes object.
+   * Verifies that a singleton {@link ArrayNode} supplied via {@code valueNode(...)} for a multivalued attribute
+   * is preserved as an array on the wire and not unwrapped into a scalar merely because the path is set after
+   * the value in the builder.
    *
    * <pre>{@code
-   * Input valueNode:
-   * [{
-   *   "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-   *   "externalId": "external-id",
-   *   "displayName": "example/developers"
-   * }]
-   *
-   * Serialized operation:
-   * {
-   *   "op": "replace",
-   *   "value": {
-   *     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-   *     "externalId": "external-id",
-   *     "displayName": "example/developers"
-   *   }
-   * }
+   * Input:  path="roles", valueNode=["ADMIN"]
+   * Output: {"op":"add","path":"roles","value":["ADMIN"]}
    * }</pre>
    *
-   * The output must contain neither {@code "value":[{...}]} nor an escaped JSON string.
+   * Regression test for the over-broad singleton-array unwrap that also stripped singleton arrays from
+   * multivalued attributes.
    *
-   * @see <a href="https://github.com/Captain-P-Goldfish/scim-for-keycloak/issues/172">scim-for-keycloak issue
-   *      #172</a>
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
    */
   @Test
-  @DisplayName("Pathless replace serializes a singleton resource array as an object")
-  public void testPathlessReplaceWithSingletonResourceArray()
+  @DisplayName("Singleton array value for a multivalued attribute is preserved as an array")
+  public void testSingletonArrayForMultivaluedAttributeIsPreserved()
   {
-    Group group = Group.builder().externalId("external-id").displayName("example/developers").build();
-    ArrayNode groupArray = new ArrayNode(JsonNodeFactory.instance);
-    groupArray.add(group);
+    ArrayNode roles = new ArrayNode(JsonNodeFactory.instance);
+    roles.add("ADMIN");
 
-    PatchRequestOperation operation = PatchRequestOperation.builder().op(PatchOp.REPLACE).valueNode(groupArray).build();
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.ADD)
+                                                           .path("roles")
+                                                           .valueNode(roles)
+                                                           .build();
 
-    JsonNode serializedOperation = JsonHelper.readJsonDocument(operation.toString());
-    Assertions.assertFalse(serializedOperation.has(AttributeNames.RFC7643.PATH));
-    Assertions.assertTrue(serializedOperation.get(AttributeNames.RFC7643.VALUE).isObject(), operation.toString());
-    Assertions.assertEquals("example/developers",
-                            serializedOperation.get(AttributeNames.RFC7643.VALUE).get("displayName").textValue());
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(internalValue, operation.toString());
+    Assertions.assertTrue(internalValue.isArray(), "multivalued attribute value must remain an array: " + operation);
+    Assertions.assertEquals(1, internalValue.size());
+    Assertions.assertEquals("ADMIN", internalValue.get(0).asText());
+
+    JsonNode serialized = JsonHelper.readJsonDocument(operation.toString());
+    Assertions.assertTrue(serialized.get(AttributeNames.RFC7643.VALUE).isArray(), operation.toString());
+    Assertions.assertEquals("ADMIN", serialized.get(AttributeNames.RFC7643.VALUE).get(0).asText());
+  }
+
+  /**
+   * Verifies that a singleton list supplied via {@code values(...)} is preserved as an array on the wire and
+   * not collapsed into a scalar. A single value supplied as a list is structurally distinct from a single
+   * string supplied via {@code value(...)}/{@code valueNode(...)}, and the builder must not erase that
+   * distinction.
+   *
+   * <pre>{@code
+   * Input:  path="roles", values=["ADMIN"]
+   * Output: {"op":"add","path":"roles","value":["ADMIN"]}
+   * }</pre>
+   *
+   * Contrast with {@link #testSingletonArrayForMultivaluedAttributeIsPreserved()} which uses
+   * {@code valueNode(ArrayNode)} and with {@link #testValueSerializationIsOrderIndependent()} which uses
+   * {@code setValue(String)} for a scalar. Regression test for the 1.34.0 singleton-list collapse that made
+   * {@code values(["ADMIN"])} and {@code value("ADMIN")} indistinguishable on the wire.
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("Singleton list via values(...) is preserved as an array on the wire")
+  public void testSingletonListViaValuesIsPreservedAsArray()
+  {
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.ADD)
+                                                           .path("roles")
+                                                           .values(Collections.singletonList("ADMIN"))
+                                                           .build();
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(internalValue, operation.toString());
+    Assertions.assertTrue(internalValue.isArray(),
+                          "a singleton list supplied via values(...) must remain an array: " + operation);
+    Assertions.assertEquals(1, internalValue.size());
+    Assertions.assertEquals("ADMIN", internalValue.get(0).asText());
+
+    JsonNode serialized = JsonHelper.readJsonDocument(operation.toString());
+    Assertions.assertTrue(serialized.get(AttributeNames.RFC7643.VALUE).isArray(), operation.toString());
+    Assertions.assertEquals("ADMIN", serialized.get(AttributeNames.RFC7643.VALUE).get(0).asText());
+  }
+
+  /**
+   * Verifies that a singleton array of complex objects supplied via {@code valueNode(...)} for a multivalued
+   * complex attribute (e.g. {@code emails}) is preserved as an array on the wire and not unwrapped into a
+   * single object merely because the path is set after the value in the builder.
+   *
+   * <pre>{@code
+   * Input:  path="emails", valueNode=[{"value":"x@y.z","type":"work"}]
+   * Output: {"op":"add","path":"emails","value":[{"value":"x@y.z","type":"work"}]}
+   * }</pre>
+   *
+   * Regression test for the over-broad singleton-array unwrap that also collapsed singleton complex arrays
+   * (e.g. {@code [{...}]} into {@code {...}}) for multivalued complex attributes.
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("Singleton array of complex objects for a multivalued complex attribute is preserved as an array")
+  public void testSingletonComplexArrayForMultivaluedComplexAttributeIsPreserved()
+  {
+    ObjectNode email = new ObjectNode(JsonNodeFactory.instance);
+    email.put("value", "x@y.z");
+    email.put("type", "work");
+    ArrayNode emails = new ArrayNode(JsonNodeFactory.instance);
+    emails.add(email);
+
+    PatchRequestOperation operation = PatchRequestOperation.builder()
+                                                           .op(PatchOp.ADD)
+                                                           .path("emails")
+                                                           .valueNode(emails)
+                                                           .build();
+
+    JsonNode internalValue = operation.get(AttributeNames.RFC7643.VALUE);
+    Assertions.assertNotNull(internalValue, operation.toString());
+    Assertions.assertTrue(internalValue.isArray(),
+                          "multivalued complex attribute value must remain an array: " + operation);
+    Assertions.assertEquals(1, internalValue.size());
+    Assertions.assertTrue(internalValue.get(0).isObject());
+    Assertions.assertEquals("x@y.z", internalValue.get(0).get("value").asText());
+
+    JsonNode serialized = JsonHelper.readJsonDocument(operation.toString());
+    Assertions.assertTrue(serialized.get(AttributeNames.RFC7643.VALUE).isArray(), operation.toString());
+    Assertions.assertTrue(serialized.get(AttributeNames.RFC7643.VALUE).get(0).isObject());
+    Assertions.assertEquals("x@y.z", serialized.get(AttributeNames.RFC7643.VALUE).get(0).get("value").asText());
+  }
+
+  /**
+   * Verifies that {@code valueNode(...)}/{@code setValue}/{@code setValues} serialize identically regardless of
+   * whether {@code setPath} is called before or after the value setter. The setters store the supplied form
+   * verbatim and do not branch on the path, so the order no longer affects the result.
+   *
+   * <pre>{@code
+   * path-based scalar (preferredLanguage):  "value":"de"       in both orders
+   * path-based multivalued (roles):          "value":["ADMIN"]  in both orders
+   * }</pre>
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("value serialization is independent of path-before-value vs value-before-path order")
+  public void testValueSerializationIsOrderIndependent()
+  {
+    // path-based scalar: setValue before setPath vs setPath before setValue
+    PatchRequestOperation valueFirst = new PatchRequestOperation();
+    valueFirst.setOp(PatchOp.REPLACE);
+    valueFirst.setValue("de");
+    valueFirst.setPath("preferredLanguage");
+
+    PatchRequestOperation pathFirst = new PatchRequestOperation();
+    pathFirst.setOp(PatchOp.REPLACE);
+    pathFirst.setPath("preferredLanguage");
+    pathFirst.setValue("de");
+
+    Assertions.assertEquals("de", valueFirst.get(AttributeNames.RFC7643.VALUE).textValue(), valueFirst.toString());
+    Assertions.assertEquals(JsonHelper.readJsonDocument(valueFirst.toString()),
+                            JsonHelper.readJsonDocument(pathFirst.toString()),
+                            "order must not affect path-based scalar");
+
+    // path-based multivalued array: valueNode before setPath vs setPath before valueNode
+    ArrayNode roles = new ArrayNode(JsonNodeFactory.instance);
+    roles.add("ADMIN");
+    PatchRequestOperation arrayValueFirst = new PatchRequestOperation();
+    arrayValueFirst.setOp(PatchOp.ADD);
+    arrayValueFirst.setValueNode(roles);
+    arrayValueFirst.setPath("roles");
+
+    PatchRequestOperation arrayPathFirst = new PatchRequestOperation();
+    arrayPathFirst.setOp(PatchOp.ADD);
+    arrayPathFirst.setPath("roles");
+    arrayPathFirst.setValueNode(roles);
+
+    Assertions.assertTrue(arrayValueFirst.get(AttributeNames.RFC7643.VALUE).isArray(), arrayValueFirst.toString());
+    Assertions.assertEquals(JsonHelper.readJsonDocument(arrayValueFirst.toString()),
+                            JsonHelper.readJsonDocument(arrayPathFirst.toString()),
+                            "order must not affect path-based multivalued array");
   }
 
 }

--- a/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/PatchAddResourceHandlerTest.java
+++ b/scim-sdk-server/src/test/java/de/captaingoldfish/scim/sdk/server/patch/PatchAddResourceHandlerTest.java
@@ -52,6 +52,7 @@ import de.captaingoldfish.scim.sdk.common.resources.base.ScimObjectNode;
 import de.captaingoldfish.scim.sdk.common.resources.complex.Meta;
 import de.captaingoldfish.scim.sdk.common.resources.complex.Name;
 import de.captaingoldfish.scim.sdk.common.resources.complex.PatchConfig;
+import de.captaingoldfish.scim.sdk.common.resources.multicomplex.Address;
 import de.captaingoldfish.scim.sdk.common.resources.multicomplex.Email;
 import de.captaingoldfish.scim.sdk.common.resources.multicomplex.PersonRole;
 import de.captaingoldfish.scim.sdk.common.response.ErrorResponse;
@@ -2971,5 +2972,49 @@ public class PatchAddResourceHandlerTest implements FileReferences
     private String attributeName;
 
     private JsonNode value;
+  }
+
+  /**
+   * verifies that a PATCH replace on a sub-attribute of a multivalued complex attribute selected by a value
+   * filter (e.g. {@code addresses[type eq "work"].streetAddress}) preserves the full multi-word string value.
+   * This is a regression test for the 1.34.0 truncation bug reported in SCIM-SDK issue #968 where the scalar
+   * value was parsed as JSON and only the leading token (e.g. {@code 7070} of {@code 7070 Phoebe Hollow}) was
+   * kept.
+   *
+   * @see <a href="https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/968">SCIM-SDK issue #968</a>
+   */
+  @Test
+  @DisplayName("replace sub-attribute by value-filter preserves multi-word string value")
+  public void testReplaceFilteredSubAttributePreservesMultiWordValue()
+  {
+    UserHandlerImpl userHandler = new UserHandlerImpl(false);
+    UserEndpointDefinition endpointDefinition = new UserEndpointDefinition(userHandler);
+    ResourceType userResourceType = resourceEndpoint.registerEndpoint(endpointDefinition);
+
+    Address workAddress = Address.builder().type("work").streetAddress("910 Broadway").locality("New York").build();
+    Address homeAddress = Address.builder().type("home").streetAddress("1 Home Lane").build();
+    User user = User.builder().userName("John Smith").addresses(Arrays.asList(workAddress, homeAddress)).build();
+
+    final String newValue = "7070 Phoebe Hollow";
+    List<PatchRequestOperation> operations = Arrays.asList(PatchRequestOperation.builder()
+                                                                                .op(PatchOp.REPLACE)
+                                                                                .path("addresses[type eq \"work\"].streetAddress")
+                                                                                .value(newValue)
+                                                                                .build());
+    PatchOpRequest patchOpRequest = PatchOpRequest.builder().operations(operations).build();
+    addUserToProvider(userHandler, user);
+    PatchRequestHandler<User> patchRequestHandler = new PatchRequestHandler(user.getId().get(),
+                                                                            userResourceType.getResourceHandlerImpl(),
+                                                                            resourceEndpoint.getPatchWorkarounds(),
+                                                                            new Context(null));
+
+    User patchedUser = patchRequestHandler.handlePatchRequest(patchOpRequest);
+    Assertions.assertTrue(patchRequestHandler.isResourceChanged());
+    Assertions.assertEquals(2, patchedUser.getAddresses().size(), patchedUser.toPrettyString());
+    Assertions.assertEquals(newValue,
+                            patchedUser.getAddresses().get(0).getStreetAddress().get(),
+                            patchedUser.toPrettyString());
+    Assertions.assertEquals("New York", patchedUser.getAddresses().get(0).getLocality().get());
+    Assertions.assertEquals("1 Home Lane", patchedUser.getAddresses().get(1).getStreetAddress().get());
   }
 }


### PR DESCRIPTION
 Fixes #968 (the parts that remained after f618908a).

 ### Problem

 In 1.34.0 the PatchRequestOperation value setters collapsed the caller's structural choice into the same wire form, producing several regressions:

 - Singleton arrays for multivalued attributes were unwrapped to scalars. valueNode(["ADMIN"]) for a path-based multivalued attribute (e.g. roles) serialized as "value":"ADMIN" instead of "value":["ADMIN"], because
   the singleton-array unwrap branched on path presence — which depends on setter call order.
 - value("x") and values(["x"]) were indistinguishable. Both serialized as a scalar "value":"x", because builder.value(String) funneled its single string through the type-erasing values(List) adapter and setValues
   then collapsed the singleton list.
 - Path-based scalar values were order-dependent. setValue/setValues wrapped a single value into an array when the path was already set, and setPath later unwrapped it — a round-trip that made the result depend on
   whether setPath was called before or after the value setter.

 ### Fix

 Each setter now stores its input verbatim, preserving the caller's JSON type end-to-end:

 - setValue(String) stores a scalar string.
 - builder.value(String) routes through valueNode(TextNode) instead of values(List), so a single string and a singleton list are distinguishable on the wire.
 - setValues(List) always stores a JSON array; a singleton list stays an array.
 - setValueNode(JsonNode) stores the node verbatim with no eager unwrap, so multivalued arrays like ["ADMIN"] or [{...}] are preserved.

 No construction-time normalization remains. The pathless resource-update unwrap added for scim-for-keycloak#172 was an implicit transformation applied while the operation was still being built — which is what made
 the result order-dependent. It is removed together with its locking test (testPathlessReplaceWithSingletonResourceArray). Callers who supply a singleton object array for a pathless operation should pass the object
 directly instead. This keeps the operation a faithful representation of the caller's input at all times, with no configuration needed to obtain a SCIM-compliant wire form.

 All setters are now independent of the order in which setPath is called.

 ### Tests

 Regression tests added in PatchRequestOperationTest:
 - testSingletonArrayForMultivaluedAttributeIsPreserved — scalar singleton array via valueNode.
 - testSingletonComplexArrayForMultivaluedComplexAttributeIsPreserved — complex singleton array via valueNode.
 - testSingletonListViaValuesIsPreservedAsArray — singleton list via values stays an array.
 - testValueSerializationIsOrderIndependent — path-before-value vs value-before-path for scalar and multivalued.

 Server-side regression test in PatchAddResourceHandlerTest:
 - testReplaceFilteredSubAttributePreservesMultiWordValue — pins the multi-word sub-attribute replace that f618908a fixed (e.g. addresses[type eq "work"].streetAddress → "7070 Phoebe Hollow" no longer truncated to
   7070).

 ### Verification

 - mvn test — full suite green across scim-sdk-common (479), scim-sdk-server (2411), scim-sdk-client (380).
 - mvn formatter:validate — clean.

 ────────────────────────────────────────────────────────────────────────────────

 ### A note on the pathless unwrap

 The construction-time unwrapSingletonArrayValue (the scim-for-keycloak#172 fix) is removed here. With the setters storing verbatim and no eager unwrap at setValueNode, there is no longer an internal round-trip
 that needs undoing, so the unwrap has no role left. The only behavior change is that a caller who explicitly passes valueNode([resourceObject]) to a pathless operation now gets value:[{...}] rather than
 value:{...}; passing the resource object directly via valueNode(resourceObject) gives the SCIM-compliant object form. I believe this is the cleaner direction, but I'm happy to discuss it if the maintainer prefers
 to keep a normalization path.